### PR TITLE
fix(wc): add the WC Esc page label keys to all 26 languages

### DIFF
--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -3,6 +3,9 @@
     <texts>
         <!-- BUILD 11:27 F155 Esc RF button labels -->
         <text name="wc_rf_pda_open_manager" text="Abrir gerenciador de trabalhadores" />
+        <text name="wc_rf_pda_page_dashboard" text="Painel"/>
+        <text name="wc_rf_pda_page_wages" text="Salários"/>
+        <text name="wc_rf_pda_page_workers" text="Trabalhadores"/>
         <text name="sf_pda_btn_rotation_planner" text="Planejador de rotação" />
         <text name="sf_pda_btn_field_detail" text="Detalhe do campo" />
     </texts>

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -3,6 +3,9 @@
     <texts>
         <!-- BUILD 11:27 F155 Esc RF button labels -->
         <text name="wc_rf_pda_open_manager" text="開啟工人管理員" />
+        <text name="wc_rf_pda_page_dashboard" text="儀表板"/>
+        <text name="wc_rf_pda_page_wages" text="工資"/>
+        <text name="wc_rf_pda_page_workers" text="工人"/>
         <text name="sf_pda_btn_rotation_planner" text="輪作規劃" />
         <text name="sf_pda_btn_field_detail" text="田地詳情" />
     </texts>

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -3,6 +3,9 @@
     <texts>
         <!-- BUILD 11:27 F155 Esc RF button labels -->
         <text name="wc_rf_pda_open_manager" text="Otevřít správce pracovníků" />
+        <text name="wc_rf_pda_page_dashboard" text="Přehled"/>
+        <text name="wc_rf_pda_page_wages" text="Mzdy"/>
+        <text name="wc_rf_pda_page_workers" text="Pracovníci"/>
         <text name="sf_pda_btn_rotation_planner" text="Plánovač osevního postupu" />
         <text name="sf_pda_btn_field_detail" text="Detail pole" />
     </texts>

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -3,6 +3,9 @@
     <texts>
         <!-- BUILD 11:27 F155 Esc RF button labels -->
         <text name="wc_rf_pda_open_manager" text="Åbn medarbejderstyring" />
+        <text name="wc_rf_pda_page_dashboard" text="Oversigt"/>
+        <text name="wc_rf_pda_page_wages" text="Lønninger"/>
+        <text name="wc_rf_pda_page_workers" text="Medarbejdere"/>
         <text name="sf_pda_btn_rotation_planner" text="Rotationsplanlægger" />
         <text name="sf_pda_btn_field_detail" text="Markdetaljer" />
     </texts>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -3,6 +3,9 @@
     <texts>
         <!-- BUILD 11:27 F155 Esc RF button labels -->
         <text name="wc_rf_pda_open_manager" text="Arbeitermanager öffnen" />
+        <text name="wc_rf_pda_page_dashboard" text="Übersicht"/>
+        <text name="wc_rf_pda_page_wages" text="Löhne"/>
+        <text name="wc_rf_pda_page_workers" text="Arbeiter"/>
         <text name="sf_pda_btn_rotation_planner" text="Fruchtfolgeplaner" />
         <text name="sf_pda_btn_field_detail" text="Felddetails" />
     </texts>

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -3,6 +3,9 @@
     <texts>
         <!-- BUILD 11:27 F155 Esc RF button labels -->
         <text name="wc_rf_pda_open_manager" text="Abrir gestor de trabajadores" />
+        <text name="wc_rf_pda_page_dashboard" text="Panel"/>
+        <text name="wc_rf_pda_page_wages" text="Salarios"/>
+        <text name="wc_rf_pda_page_workers" text="Trabajadores"/>
         <text name="sf_pda_btn_rotation_planner" text="Planificador de rotación" />
         <text name="sf_pda_btn_field_detail" text="Detalle del campo" />
     </texts>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -3,6 +3,9 @@
     <texts>
         <!-- BUILD 11:27 F155 Esc RF button labels -->
         <text name="wc_rf_pda_open_manager" text="Open Worker Manager" />
+        <text name="wc_rf_pda_page_dashboard" text="Dashboard"/>
+        <text name="wc_rf_pda_page_wages" text="Wages"/>
+        <text name="wc_rf_pda_page_workers" text="Workers"/>
         <text name="sf_pda_btn_rotation_planner" text="Rotation Planner" />
         <text name="sf_pda_btn_field_detail" text="Field Detail" />
     </texts>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -3,6 +3,9 @@
     <texts>
         <!-- BUILD 11:27 F155 Esc RF button labels -->
         <text name="wc_rf_pda_open_manager" text="Abrir gestor de trabajadores" />
+        <text name="wc_rf_pda_page_dashboard" text="Panel"/>
+        <text name="wc_rf_pda_page_wages" text="Salarios"/>
+        <text name="wc_rf_pda_page_workers" text="Trabajadores"/>
         <text name="sf_pda_btn_rotation_planner" text="Planificador de rotación" />
         <text name="sf_pda_btn_field_detail" text="Detalle del campo" />
     </texts>

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -3,6 +3,9 @@
     <texts>
         <!-- BUILD 11:27 F155 Esc RF button labels -->
         <text name="wc_rf_pda_open_manager" text="Ouvrir le gestionnaire d'ouvriers" />
+        <text name="wc_rf_pda_page_dashboard" text="Tableau de bord"/>
+        <text name="wc_rf_pda_page_wages" text="Salaires"/>
+        <text name="wc_rf_pda_page_workers" text="Ouvriers"/>
         <text name="sf_pda_btn_rotation_planner" text="Planificateur de rotation" />
         <text name="sf_pda_btn_field_detail" text="Détail du champ" />
     </texts>

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -3,6 +3,9 @@
     <texts>
         <!-- BUILD 11:27 F155 Esc RF button labels -->
         <text name="wc_rf_pda_open_manager" text="Avaa työntekijähallinta" />
+        <text name="wc_rf_pda_page_dashboard" text="Yleisnäkymä"/>
+        <text name="wc_rf_pda_page_wages" text="Palkat"/>
+        <text name="wc_rf_pda_page_workers" text="Työntekijät"/>
         <text name="sf_pda_btn_rotation_planner" text="Viljelykiertosuunnittelija" />
         <text name="sf_pda_btn_field_detail" text="Pellon tiedot" />
     </texts>

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -3,6 +3,9 @@
     <texts>
         <!-- BUILD 11:27 F155 Esc RF button labels -->
         <text name="wc_rf_pda_open_manager" text="Ouvrir le gestionnaire d'ouvriers" />
+        <text name="wc_rf_pda_page_dashboard" text="Tableau de bord"/>
+        <text name="wc_rf_pda_page_wages" text="Salaires"/>
+        <text name="wc_rf_pda_page_workers" text="Ouvriers"/>
         <text name="sf_pda_btn_rotation_planner" text="Planificateur de rotation" />
         <text name="sf_pda_btn_field_detail" text="Détail du champ" />
     </texts>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -3,6 +3,9 @@
     <texts>
         <!-- BUILD 11:27 F155 Esc RF button labels -->
         <text name="wc_rf_pda_open_manager" text="Dolgozókezelő megnyitása" />
+        <text name="wc_rf_pda_page_dashboard" text="Áttekintés"/>
+        <text name="wc_rf_pda_page_wages" text="Bérek"/>
+        <text name="wc_rf_pda_page_workers" text="Dolgozók"/>
         <text name="sf_pda_btn_rotation_planner" text="Vetésforgó-tervező" />
         <text name="sf_pda_btn_field_detail" text="Táblarészletek" />
     </texts>

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -3,6 +3,9 @@
     <texts>
         <!-- BUILD 11:27 F155 Esc RF button labels -->
         <text name="wc_rf_pda_open_manager" text="Buka manajer pekerja" />
+        <text name="wc_rf_pda_page_dashboard" text="Dasbor"/>
+        <text name="wc_rf_pda_page_wages" text="Upah"/>
+        <text name="wc_rf_pda_page_workers" text="Pekerja"/>
         <text name="sf_pda_btn_rotation_planner" text="Perencana rotasi" />
         <text name="sf_pda_btn_field_detail" text="Detail lahan" />
     </texts>

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -3,6 +3,9 @@
     <texts>
         <!-- BUILD 11:27 F155 Esc RF button labels -->
         <text name="wc_rf_pda_open_manager" text="Apri gestore operai" />
+        <text name="wc_rf_pda_page_dashboard" text="Pannello"/>
+        <text name="wc_rf_pda_page_wages" text="Salari"/>
+        <text name="wc_rf_pda_page_workers" text="Operai"/>
         <text name="sf_pda_btn_rotation_planner" text="Pianificatore rotazioni" />
         <text name="sf_pda_btn_field_detail" text="Dettaglio campo" />
     </texts>

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -3,6 +3,9 @@
     <texts>
         <!-- BUILD 11:27 F155 Esc RF button labels -->
         <text name="wc_rf_pda_open_manager" text="作業員マネージャーを開く" />
+        <text name="wc_rf_pda_page_dashboard" text="ダッシュボード"/>
+        <text name="wc_rf_pda_page_wages" text="賃金"/>
+        <text name="wc_rf_pda_page_workers" text="作業員"/>
         <text name="sf_pda_btn_rotation_planner" text="輪作プランナー" />
         <text name="sf_pda_btn_field_detail" text="畑の詳細" />
     </texts>

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -3,6 +3,9 @@
     <texts>
         <!-- BUILD 11:27 F155 Esc RF button labels -->
         <text name="wc_rf_pda_open_manager" text="작업자 관리자 열기" />
+        <text name="wc_rf_pda_page_dashboard" text="대시보드"/>
+        <text name="wc_rf_pda_page_wages" text="임금"/>
+        <text name="wc_rf_pda_page_workers" text="작업자"/>
         <text name="sf_pda_btn_rotation_planner" text="윤작 계획기" />
         <text name="sf_pda_btn_field_detail" text="밯 상세" />
     </texts>

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -3,6 +3,9 @@
     <texts>
         <!-- BUILD 11:27 F155 Esc RF button labels -->
         <text name="wc_rf_pda_open_manager" text="Werkersbeheer openen" />
+        <text name="wc_rf_pda_page_dashboard" text="Overzicht"/>
+        <text name="wc_rf_pda_page_wages" text="Lonen"/>
+        <text name="wc_rf_pda_page_workers" text="Werkers"/>
         <text name="sf_pda_btn_rotation_planner" text="Rotatieplanner" />
         <text name="sf_pda_btn_field_detail" text="Veldgegevens" />
     </texts>

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -3,6 +3,9 @@
     <texts>
         <!-- BUILD 11:27 F155 Esc RF button labels -->
         <text name="wc_rf_pda_open_manager" text="Åpne arbeiderbehandler" />
+        <text name="wc_rf_pda_page_dashboard" text="Oversikt"/>
+        <text name="wc_rf_pda_page_wages" text="Lønninger"/>
+        <text name="wc_rf_pda_page_workers" text="Arbeidere"/>
         <text name="sf_pda_btn_rotation_planner" text="Rotasjonsplanlegger" />
         <text name="sf_pda_btn_field_detail" text="Feltdetaljer" />
     </texts>

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -3,6 +3,9 @@
     <texts>
         <!-- BUILD 11:27 F155 Esc RF button labels -->
         <text name="wc_rf_pda_open_manager" text="Otwórz menedżera pracowników" />
+        <text name="wc_rf_pda_page_dashboard" text="Pulpit"/>
+        <text name="wc_rf_pda_page_wages" text="Płace"/>
+        <text name="wc_rf_pda_page_workers" text="Pracownicy"/>
         <text name="sf_pda_btn_rotation_planner" text="Planer płodozmianu" />
         <text name="sf_pda_btn_field_detail" text="Szczegóły pola" />
     </texts>

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -3,6 +3,9 @@
     <texts>
         <!-- BUILD 11:27 F155 Esc RF button labels -->
         <text name="wc_rf_pda_open_manager" text="Abrir gestor de trabalhadores" />
+        <text name="wc_rf_pda_page_dashboard" text="Painel"/>
+        <text name="wc_rf_pda_page_wages" text="Salários"/>
+        <text name="wc_rf_pda_page_workers" text="Trabalhadores"/>
         <text name="sf_pda_btn_rotation_planner" text="Planeador de rotação" />
         <text name="sf_pda_btn_field_detail" text="Detalhe do campo" />
     </texts>

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -3,6 +3,9 @@
     <texts>
         <!-- BUILD 11:27 F155 Esc RF button labels -->
         <text name="wc_rf_pda_open_manager" text="Deschide managerul de muncitori" />
+        <text name="wc_rf_pda_page_dashboard" text="Panou"/>
+        <text name="wc_rf_pda_page_wages" text="Salarii"/>
+        <text name="wc_rf_pda_page_workers" text="Muncitori"/>
         <text name="sf_pda_btn_rotation_planner" text="Planificator de rotație" />
         <text name="sf_pda_btn_field_detail" text="Detaliu câmp" />
     </texts>

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -3,6 +3,9 @@
     <texts>
         <!-- BUILD 11:27 F155 Esc RF button labels -->
         <text name="wc_rf_pda_open_manager" text="Открыть менеджер работников" />
+        <text name="wc_rf_pda_page_dashboard" text="Панель"/>
+        <text name="wc_rf_pda_page_wages" text="Зарплаты"/>
+        <text name="wc_rf_pda_page_workers" text="Работники"/>
         <text name="sf_pda_btn_rotation_planner" text="Планировщик севооборота" />
         <text name="sf_pda_btn_field_detail" text="Сведения о поле" />
     </texts>

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -3,6 +3,9 @@
     <texts>
         <!-- BUILD 11:27 F155 Esc RF button labels -->
         <text name="wc_rf_pda_open_manager" text="Öppna arbetshanteraren" />
+        <text name="wc_rf_pda_page_dashboard" text="Översikt"/>
+        <text name="wc_rf_pda_page_wages" text="Löner"/>
+        <text name="wc_rf_pda_page_workers" text="Arbetare"/>
         <text name="sf_pda_btn_rotation_planner" text="Växtföljdsplanerare" />
         <text name="sf_pda_btn_field_detail" text="Fältdetaljer" />
     </texts>

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -3,6 +3,9 @@
     <texts>
         <!-- BUILD 11:27 F155 Esc RF button labels -->
         <text name="wc_rf_pda_open_manager" text="İşçi yöneticisini aç" />
+        <text name="wc_rf_pda_page_dashboard" text="Panel"/>
+        <text name="wc_rf_pda_page_wages" text="Ücretler"/>
+        <text name="wc_rf_pda_page_workers" text="İşçiler"/>
         <text name="sf_pda_btn_rotation_planner" text="Ekim nöbeti planlayıcı" />
         <text name="sf_pda_btn_field_detail" text="Tarla detayı" />
     </texts>

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -3,6 +3,9 @@
     <texts>
         <!-- BUILD 11:27 F155 Esc RF button labels -->
         <text name="wc_rf_pda_open_manager" text="Відкрити менеджер працівників" />
+        <text name="wc_rf_pda_page_dashboard" text="Панель"/>
+        <text name="wc_rf_pda_page_wages" text="Зарплати"/>
+        <text name="wc_rf_pda_page_workers" text="Працівники"/>
         <text name="sf_pda_btn_rotation_planner" text="Планувальник сівозміни" />
         <text name="sf_pda_btn_field_detail" text="Деталі поля" />
     </texts>

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -3,6 +3,9 @@
     <texts>
         <!-- BUILD 11:27 F155 Esc RF button labels -->
         <text name="wc_rf_pda_open_manager" text="Mở trình quản lý công nhân" />
+        <text name="wc_rf_pda_page_dashboard" text="Bảng điều khiển"/>
+        <text name="wc_rf_pda_page_wages" text="Tiền lương"/>
+        <text name="wc_rf_pda_page_workers" text="Công nhân"/>
         <text name="sf_pda_btn_rotation_planner" text="Lập kế hoạch luân canh" />
         <text name="sf_pda_btn_field_detail" text="Chi tiết thửa ruộng" />
     </texts>


### PR DESCRIPTION
WcRfPdaGuest renders the WC page labels through wc_rf_pda_page_dashboard / wc_rf_pda_page_wages / wc_rf_pda_page_workers, but those keys never existed in the translations, so every language fell back to the English literals. Adds the keys to all 26 files with the values from the deployed pre-release pack.