### PR TITLE
feat: register Control Center action delegates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ the repo's git history and README.
 
 ### Added
 - Changelog file established (suite ruling 2026-08-22).
+- Control Center action: `WC_OPEN_ROSTER` opens the Worker Costs roster from the suite Control Center (requires SettingsHub).
 
 ## [2.2.3.45] - 2026-08-22
 

--- a/src/main.lua
+++ b/src/main.lua
@@ -124,6 +124,33 @@ end
 -- Hook into Mission lifecycle
 Mission00.load = Utils.prependedFunction(Mission00.load, load)
 Mission00.loadMission00Finished = Utils.appendedFunction(Mission00.loadMission00Finished, loadedMission)
+
+-- ---------------------------------------------------------
+-- Realistic Farming Control Center: publish a runnable delegate.
+-- Both the registry and the manager are read off g_currentMission at call time,
+-- which is the only channel that carries live between mod environments and also
+-- avoids capturing a manager that a reload has since replaced.
+-- ---------------------------------------------------------
+local function registerControlCenterActions()
+    local registry = g_currentMission ~= nil and g_currentMission.rfActionRegistry or nil
+    if registry == nil then return end
+
+    registry.registerAction({
+        action = "WC_OPEN_ROSTER",
+        button = "Open",
+        -- The roster panel draws on the HUD, so the dialog has to be out of the way.
+        closeFirst = true,
+        run = function()
+            local mgr = g_currentMission ~= nil and g_currentMission.workerCostsManager or nil
+            if mgr ~= nil and mgr.onOpenRosterInput ~= nil then
+                mgr:onOpenRosterInput()
+            end
+        end,
+    })
+end
+
+Mission00.loadMission00Finished = Utils.appendedFunction(
+    Mission00.loadMission00Finished, registerControlCenterActions)
 FSBaseMission.delete = Utils.appendedFunction(FSBaseMission.delete, unload)
 
 -- Update hook


### PR DESCRIPTION
## Summary
- Publishes Control Center delegates via g_currentMission.rfActionRegistry.

## Depends on
- SettingsHub Control Center PRs.

## Test plan
- [ ] Open Control Center and verify this mod rows and buttons.