### PR TITLE
fix: read monthlyCosts entry tables in server snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ the repo's git history and README.
 - Changelog file established (suite ruling 2026-08-22).
 - Control Center action: `WC_OPEN_ROSTER` opens the Worker Costs roster from the suite Control Center (requires SettingsHub).
 
+### Fixed
+- Monthly cost summary read server-snapshot `monthlyCosts` entries as raw numbers; they are tables with an `amount` field. The accrued monthly total now reads correctly.
+
 ## [2.2.3.45] - 2026-08-22
 
 - First entry under changelog tracking.

--- a/src/WorkerManager.lua
+++ b/src/WorkerManager.lua
@@ -408,8 +408,11 @@ function WorkerManager:getServerSnapshot()
     -- Aggregate "this month" accrued wages from the worker system.
     local monthAccrued = 0
     if workerSys and workerSys.monthlyCosts then
-        for _, amt in pairs(workerSys.monthlyCosts) do
-            monthAccrued = monthAccrued + (amt or 0)
+        -- Entries are { name, amount, farmId } tables, not raw numbers.
+        for _, entry in pairs(workerSys.monthlyCosts) do
+            if entry and entry.amount then
+                monthAccrued = monthAccrued + entry.amount
+            end
         end
     end
 


### PR DESCRIPTION
## Summary`n- monthlyCosts entries are tables with amount field, not raw numbers.`n`n## Test plan`n- [ ] Verify Worker Costs monthly accrued total.