### PR TITLE
Esc door: Pro Staff Buy and Run on any host

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="92">
     <author>TisonK</author>
-    <version>2.2.3.56</version>
+    <version>2.2.3.57</version>
     <modName>FS25_WorkerCostsMod</modName>
     <title>
         <en>Realistic Worker Costs</en>

--- a/src/gui/RfPdaMenuPage.lua
+++ b/src/gui/RfPdaMenuPage.lua
@@ -213,6 +213,7 @@ local function mdResolve(bare, name)
             MDMPriceFormat = "FS25_MarketDynamics",
             CsRfPdaGuest = "FS25_SeasonalCropStress",
             NpcRfPdaGuest = "FS25_NPCFavor",
+            ProStaffRfPdaGuest = "FS25_ProStaffCoOp",
         }
         local env = g_modEnvironments[OWNER[name] or "FS25_MarketDynamics"]
         if env ~= nil and env[name] ~= nil then
@@ -1630,7 +1631,11 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     -- onShow, which runs after this. That ordering is what stops the pager following the
     -- player from NPC Favor onto Income or Dairy - those guests do not know the buttons
     -- exist and would never have hidden them.
-    for _, id in ipairs({ "rfFwPagePrev", "rfFwPageNext" }) do
+    -- BUILD 14:35 (Pro Staff Buy / Run on any Esc host): the two Pro Staff action Buttons
+    -- sit in every door copy now and ride the same every-refresh hide; ProStaffRfPdaGuest.onShow
+    -- is the only thing that turns them back on, so they never follow the player onto
+    -- another module (the rule the Pro Staff host copy has had since BUILD 00:46).
+    for _, id in ipairs({ "rfFwPagePrev", "rfFwPageNext", "rfPsBuyBtn", "rfPsFlushBtn" }) do
         local btn = self:getDescendantById(id)
         if btn ~= nil then
             btn.inputActionName = nil
@@ -2507,6 +2512,52 @@ end
 
 function RfPdaMenuPage:onClickRfFwPageNext()
     self:_rfFwPageStep(1)
+end
+
+-- ---------------------------------------------------------------------------
+-- BUILD 14:35 (Pro Staff Buy / Run on any Esc host): the two Pro Staff action Buttons
+-- (rfPsBuyBtn / rfPsFlushBtn) sit in every door copy, and the Esc page that loads is
+-- always the HOST mod's copy, so the click names must exist here too or the buttons
+-- never fire (rain-key lesson). Vendored from the Pro Staff host copy (BUILD 00:46);
+-- the guest is reached through the mission handle first, then resolved across mod
+-- environments, because bare ProStaffRfPdaGuest is nil in every env but Pro Staff's.
+-- The host owns nothing but the click: the guest decides farm, membership and count,
+-- and it calls ProStaffManager:buyLevel or ProStaffManager:requestFarmFlush and
+-- nothing else. No money is moved here.
+-- ---------------------------------------------------------------------------
+
+--- The Pro Staff guest: mission handle first (a registry built by another mod's older
+--- RfEscModules copy cannot strand the click), then the cross-env resolver.
+local function _psGuest()
+    if g_currentMission ~= nil and g_currentMission.proStaffRfPdaGuest ~= nil then
+        return g_currentMission.proStaffRfPdaGuest
+    end
+    return (type(mdResolve) == "function")
+            and mdResolve(ProStaffRfPdaGuest, "ProStaffRfPdaGuest") or ProStaffRfPdaGuest
+end
+
+function RfPdaMenuPage:onClickPsBuy()
+    local guest = _psGuest()
+    if guest == nil or type(guest.onBuy) ~= "function" then
+        return
+    end
+    local ok, err = pcall(guest.onBuy)
+    if not ok then
+        SoilLogger.warning("RfPdaMenuPage: Pro Staff buy failed: %s", tostring(err))
+    end
+    self:refreshContent(false)
+end
+
+function RfPdaMenuPage:onClickPsFlush()
+    local guest = _psGuest()
+    if guest == nil or type(guest.onFlush) ~= "function" then
+        return
+    end
+    local ok, err = pcall(guest.onFlush)
+    if not ok then
+        SoilLogger.warning("RfPdaMenuPage: Pro Staff flush failed: %s", tostring(err))
+    end
+    self:refreshContent(false)
 end
 
 --- 2026-08-22 (Wizard): pager keys are now . / > for next and , / < for back

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -648,6 +648,20 @@
                                     visible="false" text="" onClick="onClickRfFwPagePrev"/>
                             <Button profile="RF_FwPagerBtn" id="rfFwPageNext" position="1010px -396px" size="120px 24px"
                                     visible="false" text="" onClick="onClickRfFwPageNext"/>
+                            <!-- BUILD 14:35 (Ash 14:35, Wizard: build Buy / Run like the other modules): the
+                                 Pro Staff action strip, bottom-left of the same band the pager parks on (the
+                                 pager is bottom-right). In EVERY suite door copy from this build on, so the
+                                 buttons paint and click whichever mod built menuRealisticFarming. Hidden
+                                 by default and hidden again on every refresh by _syncHostGuestChrome;
+                                 ProStaffRfPdaGuest.onShow alone shows them, for the member farm only. The
+                                 host copy owns nothing but the click (onClickPsBuy / onClickPsFlush, vendored
+                                 into every host RfPdaMenuPage.lua); Buy routes to ProStaffManager:buyLevel
+                                 and Run to ProStaffManager:requestFarmFlush, no other money path exists here.
+                                 RF_FwPagerBtn: fs25_wideButton chrome, no inputAction, so no key chip. -->
+                            <Button profile="RF_FwPagerBtn" id="rfPsBuyBtn" position="10px -396px" size="240px 24px"
+                                    visible="false" text="" onClick="onClickPsBuy"/>
+                            <Button profile="RF_FwPagerBtn" id="rfPsFlushBtn" position="260px -396px" size="240px 24px"
+                                    visible="false" text="" onClick="onClickPsFlush"/>
                             <Text profile="RF_HintText" id="rfFwEmptyHint" position="10px -68px" size="1120px 44px"
                                   textMaxNumLines="2" visible="false" text=""/>
                             <Text profile="RF_HintText" id="rfFwHintTable" position="10px -336px" size="1120px 80px"


### PR DESCRIPTION
## Summary
- Put Buy and Run on the shared Realistic Farming Esc page so they work whichever companion created the tab, same as Auto/Manual and the twenty-card ladder.
- Host Lua remotes the clicks to the Pro Staff guest. Money stays buyLevel and requestFarmFlush. Dairy cards, Auto/Manual, twenty cards, and Esc after Map stay.

## Test plan
- [ ] Full client start (XML and new strings).
- [ ] With Dairy loaded, Esc Realistic Farming > Pro Staff shows Buy and Run under the twenty cards.
- [ ] Buy still purchases the next rung; Run still pays the disease flush quote.
- [ ] Buttons hide when you leave the Pro Staff module.
- [ ] Dairy barn cards and the Auto/Manual chip still open.
