### PR TITLE
Esc Worker Costs: hire and fire on the one-page glance

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="92">
     <author>TisonK</author>
-    <version>2.2.3.57</version>
+    <version>2.2.3.72</version>
     <modName>FS25_WorkerCostsMod</modName>
     <title>
         <en>Realistic Worker Costs</en>

--- a/src/gui/RfEscModules.lua
+++ b/src/gui/RfEscModules.lua
@@ -261,6 +261,11 @@ function RfEscModules:registerModule(def)
         -- MORE (1/2) button forwarded a step to nil and the roster never turned the page.
         -- The register-time warning below did name it, in a log nobody read back.
         onPageStep = def.onPageStep,
+        -- BUILD 22:42 (George CLOSED DESIGN 21:26): the Worker Costs guest registers onHire /
+        -- onFire for the Esc page Hire / Fire buttons; carried so the host forwarders reach them
+        -- through the registry (the warning below would otherwise name them as dropped).
+        onHire = def.onHire,
+        onFire = def.onFire,
     }
     -- BUILD 23:51: this whitelist has now silently eaten a handler four times, so stop
     -- letting it do that quietly. Anything a caller passed that is not carried above gets

--- a/src/gui/RfPdaMenuPage.lua
+++ b/src/gui/RfPdaMenuPage.lua
@@ -477,7 +477,6 @@ function RfPdaMenuPage:onGuiSetupFinished()
     self.mdPricesBand = self:getDescendantById("mdPricesBand") or self.mdPricesBand
     self.mdEventsBand = self:getDescendantById("mdEventsBand") or self.mdEventsBand
     self.mdContractsBand = self:getDescendantById("mdContractsBand") or self.mdContractsBand
-    self.mdOpenMarketBtn = self:getDescendantById("mdOpenMarketBtn") or self.mdOpenMarketBtn
     self.mdSubnavShell = self:getDescendantById("mdSubnavShell") or self.mdSubnavShell
     self.mdSubnavSelector = self:getDescendantById("mdSubnavSelector") or self.mdSubnavSelector
     self.mdSubnavDotBox = self:getDescendantById("mdSubnavDotBox") or self.mdSubnavDotBox
@@ -657,51 +656,9 @@ function RfPdaMenuPage:initialize()
             end
         end
     }
-    -- Open full Market when MDM module is active (bottom strip twin).
-    -- MENU_EXTRA_1, NOT MENU_ACTIVATE: the commodity SmoothList consumes ACTIVATE/SPACE
-    -- first, so the footer callback never fired at all - zero MarketScreen.show lines in
-    -- the client log on click (Ash+George r2 2026-08-07). EXTRA_1 is free while MDM is
-    -- the active module, since Help / Rotation Planner / Field Detail are Soil-only footers.
-    self.btnOpenMarket = {
-        inputAction = InputAction.MENU_EXTRA_1,
-        showWhenPaused = true,
-        text = tr("md_rf_pda_open_market", "Open full Market"),
-        callback = function()
-            print("[MarketDynamics] Esc footer Open full Market pressed")
-            -- Cross-mod resolve (Vera F2 2026-08-07). MdRfPdaGuest / MDMMarketScreen are
-            -- MarketDynamics-env globals and are nil on a Soil/WC/SCS hosted door, so the
-            -- bare calls silently did nothing there. Same shape as the Worker Manager
-            -- resolve below and Soil's soilGlobal: try in-env, then g_modEnvironments.
-            local host = self:_getHost()
-            local activeId = host ~= nil and host.activeModuleId or nil
-            local mod = (host ~= nil and host.modules ~= nil and activeId ~= nil)
-                and host.modules[activeId] or nil
-            if mod ~= nil and type(mod.onOpenFullMarket) == "function" then
-                print("[MarketDynamics] Open full Market via active module def")
-                mod.onOpenFullMarket()
-                return
-            end
-            -- BUILD 12:59: this had its own two-belt resolve (in-env, then the hardcoded
-            -- MarketDynamics env key) and neither of the belts that actually work - the
-            -- getfenv/mission publish. Routed through mdResolve so SPACE and the footer
-            -- button share one implementation and one set of five belts.
-            local guest = (type(mdResolve) == "function")
-                    and mdResolve(MdRfPdaGuest, "MdRfPdaGuest") or MdRfPdaGuest
-            if guest ~= nil and type(guest.onOpenFullMarket) == "function" then
-                print("[MarketDynamics] Open full Market via resolved MdRfPdaGuest")
-                pcall(guest.onOpenFullMarket)
-                return
-            end
-            local scr = (type(mdResolve) == "function")
-                    and mdResolve(MDMMarketScreen, "MDMMarketScreen") or MDMMarketScreen
-            if scr ~= nil and type(scr.show) == "function" then
-                print("[MarketDynamics] Open full Market via resolved MDMMarketScreen")
-                pcall(scr.show)
-                return
-            end
-            print("[MarketDynamics] Open full Market: no handler available (all resolve paths nil)")
-        end
-    }
+    -- BUILD 12:05 (George CLOSED DESIGN 09:45): the Esc footer Open full Market table is gone
+    -- with the Esc full-Market door; the Market footer is Back only. The standalone Market
+    -- screen keeps its keybind and the Control Center toggle.
     -- SPACE / MENU_ACTIVATE: open the Worker Manager deep desk when WC is active.
     self.btnOpenWorkerManager = {
         -- MENU_EXTRA_2, not MENU_ACTIVATE: same SmoothList swallow class as Open full
@@ -1504,6 +1461,7 @@ function RfPdaMenuPage:_refreshPageHeader(active)
     local isSoil = active == nil or active.id == "soilFertilizer"
     local isWc = active ~= nil and active.id == "workerCosts"
     local activeId = active ~= nil and active.id or nil
+    local isMd = activeId == "marketDynamics"
     local isFw = activeId == "income" or activeId == "tax" or activeId == "dairy"
             or activeId == "npcFavor" or activeId == "fertilizerDepot"
     if self.rfPageTitle then
@@ -1540,6 +1498,24 @@ function RfPdaMenuPage:_refreshPageHeader(active)
                 end
             end
             self.rfPageBlurb:setText(wcBlurb)
+        elseif isMd then
+            -- BUILD 16:24 (George CLOSED DESIGN 15:47): Market keeps ONE short tagline line under the
+            -- hero title (RF_PageTagline 23px; a two-line blurb reached -72 and sat on CROP / PRICE /
+            -- CHANGE at -52 - 8). The long teach lives in mdSideInfoShell (MdRfPdaGuest.paintSideInfo),
+            -- and _applyMdContentDrop lowers the content plane 24px for Market so the header row
+            -- clears this line. The text is the registered md_rf_pda_blurb (one line since 16:24).
+            if type(self.rfPageBlurb.setVisible) == "function" then
+                self.rfPageBlurb:setVisible(true)
+            end
+            local mdBlurb = active and active.blurb
+            local mdTagline = "Prices, events and contracts at a glance: pick a crop above, act below."
+            if type(mdBlurb) == "string" and mdBlurb ~= "" then
+                local lower = mdBlurb:lower()
+                if not lower:find("^missing%s") and not lower:find("^missing_") then
+                    mdTagline = mdBlurb
+                end
+            end
+            self.rfPageBlurb:setText(mdTagline)
         elseif active ~= nil and type(active.blurb) == "string" and active.blurb ~= "" then
             if type(self.rfPageBlurb.setVisible) == "function" then
                 self.rfPageBlurb:setVisible(true)
@@ -1611,6 +1587,48 @@ end
 
 --- Show/hide CS table+detail twins and WC subnav/page shells by active guest panel id.
 --- Panel id for Crop Stress guest is seasonalCropStress (not "cropStress").
+--- BUILD 16:24 (George CLOSED DESIGN 15:47, Ash ACK 16:24): on Market the content plane's TOP edge
+--- drops 24px so CROP / PRICE / CHANGE clear the one-line tagline. Lua only, Market only: the shared
+--- RF_PanelContentShell / RF_HostPlaceholderShell profiles are untouched, so Soil / Crop Stress /
+--- Worker Costs keep their plane. rfHostPlaceholder is the Market table's parent (mdTableRegion and
+--- mdPageBand live in it); rfPanelContent is Soil's plane and is hidden on Market, so it stays put.
+--- Mechanism: GuiElement:setSize with the height reduced by 24px keeps the element's position (its
+--- bottom edge; engine y grows upward) and lowers the top edge. Children re-anchor in
+--- updateAbsolutePosition: the top-anchored table (RF_MdTableRegionShell, 456 reserve) shrinks by
+--- 24px and the bottom-anchored mdPageBand and the footer do not move. Restored to the stored base
+--- height on any other door; re-based if the door XML is rebuilt (new element).
+function RfPdaMenuPage:_applyMdContentDrop(isMd)
+    local el = self.rfHostPlaceholder
+    if el == nil or type(el.setSize) ~= "function" or type(el.size) ~= "table" then
+        return
+    end
+    if self._rfHostPlaceholderBaseEl ~= el then
+        self._rfHostPlaceholderBaseEl = el
+        self._rfHostPlaceholderBaseH = el.size[2]
+        self._rfMdContentDropped = false
+    end
+    local dy = nil
+    if GuiUtils ~= nil and type(GuiUtils.getNormalizedScreenValues) == "function" then
+        local norms = GuiUtils.getNormalizedScreenValues("0px 24px")
+        if type(norms) == "table" then
+            dy = norms[2]
+        end
+    end
+    if dy == nil or self._rfHostPlaceholderBaseH == nil then
+        return
+    end
+    local wantDropped = isMd == true
+    if wantDropped == (self._rfMdContentDropped == true) then
+        return
+    end
+    if wantDropped then
+        el:setSize(nil, self._rfHostPlaceholderBaseH - dy)
+    else
+        el:setSize(nil, self._rfHostPlaceholderBaseH)
+    end
+    self._rfMdContentDropped = wantDropped
+end
+
 function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     local isSoil = activeId == nil or activeId == "soilFertilizer"
     local isCs = activeId == "seasonalCropStress"
@@ -1635,6 +1653,9 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     -- sit in every door copy now and ride the same every-refresh hide; ProStaffRfPdaGuest.onShow
     -- is the only thing that turns them back on, so they never follow the player onto
     -- another module (the rule the Pro Staff host copy has had since BUILD 00:46).
+    -- BUILD 00:06 (George CLOSED DESIGN 23:12): rfFwPagePrev / rfFwPageNext are gone from the door
+    -- XML (the NPC tables scroll), so only the Pro Staff strip rides this loop now. The ids are
+    -- looked up nil-safe, so a door copy that still carries the pager just hides it as before.
     for _, id in ipairs({ "rfFwPagePrev", "rfFwPageNext", "rfPsBuyBtn", "rfPsFlushBtn" }) do
         local btn = self:getDescendantById(id)
         if btn ~= nil then
@@ -1651,6 +1672,18 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
             if type(btn.setVisible) == "function" then
                 btn:setVisible(false)
             end
+        end
+    end
+    -- BUILD 00:06: the NPC Favor tables (two SmoothLists under rfFwTableBlock), their favors
+    -- header and empty hint go dark on every refresh; NpcRfPdaGuest.onShow alone shows them, so
+    -- Income / Dairy / Depot never inherit a live list. Nil-safe: thin doors have no such ids.
+    -- BUILD 12:05: plus the two NPC detail cards (rfFwRosterDetailCard / rfFwFavorDetailCard).
+    for _, id in ipairs({ "rfFwRosterBox", "rfFwFavorBox", "rfFwFavEmpty",
+                          "rfFwFavColGroup", "rfFwFavColWho", "rfFwFavColWhat", "rfFwFavColUrgency",
+                          "rfFwRosterDetailCard", "rfFwFavorDetailCard" }) do
+        local el = self:getDescendantById(id)
+        if el ~= nil and type(el.setVisible) == "function" then
+            el:setVisible(false)
         end
     end
     -- Action bar rides the CS module only; the guest decides the two buttons.
@@ -1709,19 +1742,16 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
         setVis(self.mdPricesBand, false)
         setVis(self.mdEventsBand, false)
         setVis(self.mdContractsBand, false)
-        setVis(self.mdOpenMarketBtn, false)
-        local btnE = self:getDescendantById("mdOpenMarketBtnEvents")
-        local btnC = self:getDescendantById("mdOpenMarketBtnContracts")
-        setVis(btnE, false)
-        setVis(btnC, false)
     end
     if not isCs then
         setVis(self.csFieldsEmptyHint, false)
     end
     -- Fresh WC: page MTO lives in sibling wcSubnavShell (NOT rfFilterBox). Brand alone in filter.
     setVis(self.wcSubnavShell, isWc)
-    setVis(self.wcSubnavSelector, isWc)
-    setVis(self.wcSubnavDotBox, isWc)
+    -- BUILD 18:26: one Worker Costs page, no picker. The shell stays (it carries wcSideInfoShell);
+    -- the selector and its dots stay hidden on every door.
+    setVis(self.wcSubnavSelector, false)
+    setVis(self.wcSubnavDotBox, false)
     -- MDM subnav twin (Prices | Events | Contracts); exclusive with WC subnav.
     setVis(self.mdSubnavShell, isMd)
     setVis(self.mdSubnavSelector, isMd)
@@ -1873,6 +1903,22 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     if isFw and self.rfPageBlurb ~= nil and type(self.rfPageBlurb.setText) == "function" then
         self.rfPageBlurb:setText("")
     end
+    -- BUILD 16:24 (George CLOSED DESIGN 15:47): rfFwHintTable sits inside rfFwTableBlock beside the
+    -- Dairy cards (-336..-388 crosses the cards' bottom band). A table door (Income / Depot / NPC)
+    -- could leave hint text in it and Dairy only blanked the text. Clear AND hide it on every
+    -- framework door show (Dairy, Income, Depot, NPC, Tax). A table guest that wants the line must
+    -- paint the text and setVisible(true) itself in its own onShow, which runs after this.
+    if isFw then
+        local fwHint = self:getDescendantById("rfFwHintTable")
+        if fwHint ~= nil then
+            if type(fwHint.setText) == "function" then
+                fwHint:setText("")
+            end
+            setVis(fwHint, false)
+        end
+    end
+    -- BUILD 16:24: Market-only content plane drop (restore on every other door, Soil included).
+    self:_applyMdContentDrop(isMd)
     setVis(self.wcGlanceShell, false)
     self:_refreshSideInfo(activeId)
     -- CS: hide host body so table+detail get room (not isWc alone - body was still on for CS).
@@ -1883,15 +1929,14 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     if (isWc or isCs or isMd or isFw) and self.rfHostBody and self.rfHostBody.setText then
         self.rfHostBody:setText("")
     end
-    -- Bottom bar: SPACE opens full Market while MDM is active.
-    if isMd and self.btnOpenMarket ~= nil then
-        self.menuButtonInfo = { self.btnBack, self.btnOpenMarket }
-        local trFn = self._rfTr
-        if type(trFn) == "function" then
-            self.btnOpenMarket.text = trFn("md_rf_pda_open_market", "Open full Market")
-        end
-    elseif isWc and self.btnOpenWorkerManager ~= nil then
-        self.menuButtonInfo = { self.btnBack, self.btnOpenWorkerManager }
+    -- BUILD 12:05 (George CLOSED DESIGN 09:45): Market footer is Back only; the Esc full-Market
+    -- door is gone (Prices / Events / Contracts are the whole Market on this page).
+    if isMd then
+        self.menuButtonInfo = { self.btnBack }
+    elseif isWc then
+        -- BUILD 22:42 (George CLOSED DESIGN 21:26): Back only. Hire / Fire live on the page
+        -- (wcBtnHireN / wcBtnFireN); Open Worker Manager is off the Esc footer.
+        self.menuButtonInfo = { self.btnBack }
     elseif isCs then
         -- BUILD Help restore 2026-08-12: Back + Help. Consultant chip stays off footer.
         self.menuButtonInfo = { self.btnBack, self.btnHelpCs }
@@ -1986,8 +2031,18 @@ function RfPdaMenuPage:_wcPageSel()
     return self.wcSubnavSelector
 end
 
---- Host-seed WC page labels once on WC enter (never from arrow click; never forceEvent).
+--- BUILD 18:26 (George CLOSED DESIGN 17:59): Worker Costs is ONE page and the page picker is
+--- gone. This used to seed three texts, three dots and a state on wcSubnavSelector; it is now
+--- a no-op that pins page 1 so _syncWcSubPageVisibility shows the merged wcPageDashboard. The
+--- selector stays declared and hidden (XML visible=false, chrome sync below keeps it off).
+--- Kept as a function so the module-switch path and any stale caller stay safe.
 function RfPdaMenuPage:_seedWcSubnavTexts()
+    self.wcSubPageIndex = 1
+    self._wcSubnavSeeded = true
+end
+
+--- Retired by BUILD 18:26 (kept for reference, never called): the three-page seed.
+function RfPdaMenuPage:_seedWcSubnavTextsRetired()
     local sel = self:_wcPageSel()
     if sel == nil then
         return
@@ -2181,6 +2236,8 @@ function RfPdaMenuPage:_seedMdSubnavTexts()
         t("md_rf_pda_page_prices", "Prices"),
         t("md_rf_pda_page_events", "Events"),
         t("md_rf_pda_page_contracts", "Contracts"),
+        -- BUILD 16:42 (George CLOSED DESIGN 16:25): three pages again; Event Settings is the
+        -- right card of the Events page, not a tab.
     }
     self._mdSubnavSeeding = true
     if sel.setTexts then
@@ -2274,11 +2331,6 @@ function RfPdaMenuPage:_syncMdSubPageVisibility()
     setVis(self.mdPricesBand, idx == 1)
     setVis(self.mdEventsBand, idx == 2)
     setVis(self.mdContractsBand, idx == 3)
-    setVis(self.mdOpenMarketBtn, idx == 1)
-    local btnE = self:getDescendantById("mdOpenMarketBtnEvents")
-    local btnC = self:getDescendantById("mdOpenMarketBtnContracts")
-    setVis(btnE, idx == 2)
-    setVis(btnC, idx == 3)
     if idx == 1 and self.mdGraphArea ~= nil and type(self.mdGraphArea.updateAbsolutePosition) == "function" then
         self.mdGraphArea:updateAbsolutePosition()
     end
@@ -2392,6 +2444,37 @@ function RfPdaMenuPage:onClickWcWageReset()
         pcall(active.onWageReset, self.rfHostPlaceholder)
     end
 end
+
+--- BUILD 22:42 (George CLOSED DESIGN 21:26): Hire / Fire from the Esc Worker Costs page. Same
+--- shape as onClickWcWageOption: the registered guest handler first (registry fields onHire /
+--- onFire, carried by RfEscModules.registerModule), the mission-published guest handle as the
+--- belt. n is the roster ROW of the last paint (recruit rows 1..4, crew rows 1..8); the guest
+--- maps it to the snapshot entry and sends the WorkerManager command.
+function RfPdaMenuPage:_wcRosterAction(kind, n)
+    local host = self:_getHost()
+    local active = host and host:getActivePanel()
+    if active ~= nil and type(active[kind]) == "function" then
+        pcall(active[kind], self.rfHostPlaceholder, n)
+        return
+    end
+    local guest = g_currentMission ~= nil and g_currentMission.WcRfPdaGuest or nil
+    if guest ~= nil and type(guest[kind]) == "function" then
+        pcall(guest[kind], self.rfHostPlaceholder, n)
+    end
+end
+
+function RfPdaMenuPage:onClickWcHire1() self:_wcRosterAction("onHire", 1) end
+function RfPdaMenuPage:onClickWcHire2() self:_wcRosterAction("onHire", 2) end
+function RfPdaMenuPage:onClickWcHire3() self:_wcRosterAction("onHire", 3) end
+function RfPdaMenuPage:onClickWcHire4() self:_wcRosterAction("onHire", 4) end
+function RfPdaMenuPage:onClickWcFire1() self:_wcRosterAction("onFire", 1) end
+function RfPdaMenuPage:onClickWcFire2() self:_wcRosterAction("onFire", 2) end
+function RfPdaMenuPage:onClickWcFire3() self:_wcRosterAction("onFire", 3) end
+function RfPdaMenuPage:onClickWcFire4() self:_wcRosterAction("onFire", 4) end
+function RfPdaMenuPage:onClickWcFire5() self:_wcRosterAction("onFire", 5) end
+function RfPdaMenuPage:onClickWcFire6() self:_wcRosterAction("onFire", 6) end
+function RfPdaMenuPage:onClickWcFire7() self:_wcRosterAction("onFire", 7) end
+function RfPdaMenuPage:onClickWcFire8() self:_wcRosterAction("onFire", 8) end
 
 
 --- Esc Crop Stress actions. The host never speaks CsDialogLoader (SCS-env-scoped,
@@ -3447,28 +3530,44 @@ function RfPdaMenuPage:_mdLogGuestBelt(mdGuest)
         tostring(mdGuest ~= nil and type(mdGuest.selectCommodityIndex) == "function")))
 end
 
-function RfPdaMenuPage:onClickMdOpenMarket()
-    -- BUILD 12:59: was the last bare cross-mod read in this file. Under a foreign door
-    -- both names were nil, so the button did nothing at all - silently, which is the
-    -- worst version. Registry first, then the resolver, and it cannot throw.
-    local host = self:_getHost()
-    local active = host and host.getActivePanel and host:getActivePanel()
-    if active ~= nil and type(active.onOpenFullMarket) == "function" then
-        pcall(active.onOpenFullMarket)
-        return
-    end
+-- BUILD 12:05: the Esc full-Market click handler is gone with the three Open full Market plates.
+
+--- BUILD 10:47 (George CLOSED DESIGN 10:37): Esc Market page D (Event Settings) and the New
+--- Contract card. The guest owns the gates (host/admin/master for settings, BetterContracts for
+--- contracts) and the server request; the host only routes the click. Same resolver belt as
+--- Open full Market above: bare global, then the owning mod env, then the mission handle the
+--- guest publishes. Deliberately not on the module registry: registerModule whitelists handler
+--- names and that file is vendored in ten mods, while this belt already works on a foreign door.
+local function _mdGuestCall(self, fnName, ...)
     local guest = (type(mdResolve) == "function")
             and mdResolve(MdRfPdaGuest, "MdRfPdaGuest") or MdRfPdaGuest
-    if guest ~= nil and type(guest.onOpenFullMarket) == "function" then
-        pcall(guest.onOpenFullMarket)
-        return
+    if guest == nil or type(guest[fnName]) ~= "function" then
+        -- Companion absent: quiet no-op, same as Open full Market.
+        return false
     end
-    local screen = (type(mdResolve) == "function")
-            and mdResolve(MDMMarketScreen, "MDMMarketScreen") or MDMMarketScreen
-    if screen ~= nil and type(screen.show) == "function" then
-        pcall(screen.show)
+    local ok, err = pcall(guest[fnName], ...)
+    if not ok then
+        print(string.format("[RfPdaMenuPage] Market guest %s failed: %s", tostring(fnName), tostring(err)))
     end
-    -- Companion absent: quiet no-op. "Works alone" means a missing peer is silence,
-    -- not an error out of a click handler.
+    return ok
+end
+
+function RfPdaMenuPage:onClickMdEventSettings()
+    _mdGuestCall(self, "onEventSettings", self.rfHostPlaceholder or self)
+end
+
+function RfPdaMenuPage:onClickMdNewContract()
+    _mdGuestCall(self, "onNewContract", self.rfHostPlaceholder or self)
+end
+
+--- Quantity / window chips. The engine hands the clicked Button to the callback
+--- (ButtonElement:sendAction raises onClickCallback with the element), and the guest reads
+--- the preset off the element id (mdNcQty5000, mdNcDays30).
+function RfPdaMenuPage:onClickMdNcQty(element)
+    _mdGuestCall(self, "onNcQty", self.rfHostPlaceholder or self, element)
+end
+
+function RfPdaMenuPage:onClickMdNcDays(element)
+    _mdGuestCall(self, "onNcDays", self.rfHostPlaceholder or self, element)
 end
 

--- a/src/gui/WcRfPdaGuest.lua
+++ b/src/gui/WcRfPdaGuest.lua
@@ -24,6 +24,11 @@ local PAGE_WORKERS = 3
 local _registered = false
 local _legacyStoodDown = false
 local _subnavSeeded = false
+-- BUILD 22:42 (George CLOSED DESIGN 21:26): the roster snapshot behind the last paint, so a
+-- Hire / Fire click on row n resolves to the entry that was on that row when it was clicked.
+local _lastSnap = nil
+local CREW_ROWS = 8      -- roster rows 1-8: crew (wcBtnFire1..8)
+local RECRUIT_ROWS = 4   -- roster rows 11-14: recruits (wcBtnHire1..4); row 9 blank, row 10 title
 
 local function tr(key, fallback)
     local modEnv = g_modEnvironments and g_modEnvironments[WC_RF_MOD_NAME]
@@ -103,6 +108,10 @@ local function setVis(el, visible)
     end
 end
 
+-- BUILD 00:06: the engine text colour setter, captured BEFORE the element helper below shadows
+-- the name (the 20:36 Market crash). The chip draw wrap resets the render colour with this one.
+local engineSetTextColor = setTextColor
+
 local function setTextColor(el, r, g, b, a)
     if el ~= nil and type(el.setTextColor) == "function" then
         el:setTextColor(r, g, b, a)
@@ -159,19 +168,11 @@ local function getPageIndex(container)
 end
 
 --- Lower WC side box: page how-to + consolidated About (no Version prefix; no About tab page).
+--- BUILD 18:26 (George CLOSED DESIGN 17:59): one page, one how-to (fallback-only key, like the
+--- three per-page keys it replaces; none of them live in the translation files).
 local function paintSideInfo(container)
-    local idx = getPageIndex(container)
-    local howTo
-    if idx == PAGE_WAGES then
-        howTo = tr("rf_pda_side_info_wc_wages",
-            "Wages\n\nAI pay: on/off, Hourly or Per hectare, Wage Level, notices.\nEscape on salary dialog = Pay (not defer). Reset = defaults.\nHire/fire in Worker Manager / Farm Tablet.")
-    elseif idx == PAGE_WORKERS then
-        howTo = tr("rf_pda_side_info_wc_workers",
-            "Workers\n\nCrew board: status, pinned, trusted, level, fatigue.\nToday's recruits and hires left. Read-only here.\nHire/fire in Worker Manager / Farm Tablet.")
-    else
-        howTo = tr("rf_pda_side_info_wc_dashboard",
-            "Dashboard\n\nWage mode, rate, active AI, next settle, month accrued.\nNames = on the clock now. Full roster on Workers.\nHire/fire in Worker Manager / Farm Tablet.")
-    end
+    local howTo = tr("rf_pda_side_info_wc",
+        "Worker Costs\n\nLeft: AI pay on/off, Hourly or Per hectare, Wage Level, notices, salary; the rate and Reset under them. Escape on the salary dialog = Pay (not defer).\nRight: status, active AI, next settle, hires left, cost per worker, interval total, month and estimate, crew; the crew board (status, pinned, trusted, level, fatigue) below.\nHire and Fire with the buttons beside the crew and recruit rows. Assign in Farm Tablet.")
     local about = tr("rf_pda_side_info_wc_about",
         "About: Midnight settle (fair 1x-120x). Settings per save; MP follows host.\nClients wait for host sync. Wage Level scales Hourly / Per hectare.\nPro-Staff links show when loaded.")
     local body = howTo .. "\n\n" .. about
@@ -181,7 +182,7 @@ local function paintSideInfo(container)
     setText(bodyEl, body)
 end
 
-local LIST_MAX_LINES = 16
+local LIST_MAX_LINES = 14  -- BUILD 12:05: fourteen declared row Texts wcRosterRow1..14 on the chip Ys
 
 local function getRosterSnap(mgr)
     if mgr == nil or type(mgr.getRosterSnapshot) ~= "function" then
@@ -248,32 +249,107 @@ local function formatRecruitLine(r)
     return string.format(tr("wc_rf_pda_recruit_line", "#%d %s · %s · %s"), slot, name, level, cost)
 end
 
+-- ============================================================
+-- BUILD 00:06 (LAW Wizard Esc overlay-chip buttons 2026-09-05, George CLOSED DESIGN 23:12): every
+-- created button on this page paints as a vanilla key chip, the CsRfPdaGuest setPivotBtn /
+-- renderPivotChip / wirePivotChipPaint chain vendored. Idle = dark plate, lime text; latched =
+-- lime plate, dark text; gated = grey, no lime. The Button keeps its own hit box and onClick
+-- (RF_CsPivotBtn: buttonActivate chrome, hideKeyboardGlyph, no global-action trigger, so SPACE
+-- never confirms); its TextElement text stays "" so the chip is the only paint.
+-- ============================================================
+local CHIP_TEXT = { 0.22323, 0.40724, 0.00368 }
+local CHIP_BG = { 0.00913, 0.01033, 0.00651 }
+local CHIP_GATED_TEXT = { 0.62, 0.64, 0.66 }
+local CHIP_GATED_BG = { 0.06, 0.06, 0.065 }
+
+--- Store the chip state on the Button and blank its text. enabled=false paints the grey chip
+--- and disables the Button; latched inverts the live chip.
+local function setChipBtn(el, label, enabled, latched)
+    if el == nil then return end
+    if type(el.setText) == "function" then el:setText("") end
+    el.rfChipLabel = label
+    el.rfChipEnabled = enabled and true or false
+    el.rfChipLatched = latched and true or false
+    if type(el.setDisabled) == "function" then el:setDisabled(not enabled) end
+end
+
+local function renderChip(el, overlay)
+    local label = el.rfChipLabel
+    if label == nil or label == "" then return end
+    if el.absPosition == nil or el.absSize == nil or el.visible == false then return end
+    local height = el.absSize[2] * 0.72
+    if height <= 0 then return end
+    local t, b, ta, ba
+    if el.rfChipEnabled and el.rfChipLatched then
+        t, b, ta, ba = CHIP_BG, CHIP_TEXT, 1.0, 1.0
+    elseif el.rfChipEnabled then
+        t, b, ta, ba = CHIP_TEXT, CHIP_BG, 1.0, 1.0
+    else
+        t, b, ta, ba = CHIP_GATED_TEXT, CHIP_GATED_BG, 0.45, 0.55
+    end
+    overlay:setColor(t[1], t[2], t[3], ta, b[1], b[2], b[3], ba)
+    local width = overlay:getButtonWidth(label, height)
+    local x = el.absPosition[1] + (el.absSize[1] - width) * 0.5
+    local y = el.absPosition[2] + (el.absSize[2] - height) * 0.5
+    overlay:renderButton(label, x, y, height, true)
+end
+
+--- Wrap one already-visible parent's draw once (guard flag on the element) so the listed chips
+--- repaint every frame the parent draws. lookup(root, id) resolves each Button. The colour reset
+--- at the end is the ENGINE global captured above, never an element helper.
+local function wireChipPaint(parent, ids, flag, lookup)
+    if parent == nil or parent[flag] then return end
+    parent[flag] = true
+    local prevDraw = parent.draw
+    function parent:draw(...)
+        if prevDraw ~= nil then prevDraw(self, ...) end
+        local idm = g_inputDisplayManager
+        if idm == nil or type(idm.getKeyboardKeyOverlay) ~= "function" then return end
+        local overlay = idm:getKeyboardKeyOverlay()
+        if overlay == nil or type(overlay.renderButton) ~= "function" then return end
+        for _, id in ipairs(ids) do
+            local el = lookup(self, id)
+            if el ~= nil then
+                pcall(renderChip, el, overlay)
+            end
+        end
+        setTextBold(false)
+        setTextAlignment(RenderText.ALIGN_LEFT)
+        setTextVerticalAlignment(RenderText.VERTICAL_ALIGN_BASELINE)
+        if type(engineSetTextColor) == "function" then
+            engineSetTextColor(1, 1, 1, 1)
+        end
+    end
+end
+
+local WC_CHIP_IDS = { "wcBtnWageReset",
+    "wcBtnFire1", "wcBtnFire2", "wcBtnFire3", "wcBtnFire4", "wcBtnFire5", "wcBtnFire6", "wcBtnFire7", "wcBtnFire8",
+    "wcBtnHire1", "wcBtnHire2", "wcBtnHire3", "wcBtnHire4" }
+
+--- The wrap goes on wcPageDashboard, the page every card and button sits in (visible whenever
+--- Worker Costs is the active module); never a new frame over the wage MTOs.
+local function wireWcChipPaint(container)
+    local page = findDescendant(container, "wcPageDashboard")
+    wireChipPaint(page, WC_CHIP_IDS, "_rfWcChipWired", function(root, id)
+        return findDescendant(root, id) or findDescendant(container, id)
+    end)
+end
+
+--- BUILD 22:42 (George CLOSED DESIGN 21:26): fixed rows, so the declared Hire / Fire buttons
+--- line up with the text. Rows 1-8 = crew (workers[1..8], blank when short, "Showing 8 of N"
+--- when long), row 9 blank, row 10 the recruits title, rows 11-14 = recruits[1..4] (blank when
+--- short). crewBudget is CREW_ROWS always; LIST_MAX_LINES 14 = 8 + 1 + 1 + 4.
 local function buildWorkersListText(snap)
     local lines = {}
     local workers = (snap and snap.workers) or {}
     local recruits = (snap and snap.recruits) or {}
     local crewTotal = #workers
-    local recruitLines = {}
-    if #recruits > 0 then
-        table.insert(recruitLines, tr("wc_rf_pda_recruits_title", "Today's recruits"))
-        for _, r in ipairs(recruits) do
-            table.insert(recruitLines, formatRecruitLine(r))
-        end
-    else
-        table.insert(recruitLines, tr("wc_rf_pda_no_recruits", "No recruits today"))
-    end
-    local recruitNeed = #recruitLines
-    local sep = 1 -- blank line between crew band and recruits
-    local crewBudget = LIST_MAX_LINES - recruitNeed - sep
-    if crewBudget < 1 then
-        crewBudget = 1
-    end
 
     local showingClause = nil
     if crewTotal == 0 then
         table.insert(lines, tr("wc_rf_pda_no_staff", "No staff yet"))
     else
-        local paintN = math.min(crewTotal, crewBudget)
+        local paintN = math.min(crewTotal, CREW_ROWS)
         if paintN < crewTotal then
             showingClause = string.format(tr("wc_rf_pda_showing_n_of_m", "Showing %d of %d"), paintN, crewTotal)
         end
@@ -281,78 +357,63 @@ local function buildWorkersListText(snap)
             table.insert(lines, formatCrewLine(workers[i]))
         end
     end
+    while #lines < CREW_ROWS do
+        table.insert(lines, "")
+    end
 
     table.insert(lines, "")
-    for _, rl in ipairs(recruitLines) do
-        table.insert(lines, rl)
-    end
-
-    -- Cap honesty: if somehow over MaxLines, trim crew first (recruits preferred).
-    while #lines > LIST_MAX_LINES and #lines > recruitNeed + 1 do
-        table.remove(lines, 1)
-        if showingClause == nil and crewTotal > 0 then
-            showingClause = string.format(tr("wc_rf_pda_showing_n_of_m", "Showing %d of %d"),
-                math.max(0, LIST_MAX_LINES - recruitNeed - 1), crewTotal)
+    if #recruits > 0 then
+        table.insert(lines, tr("wc_rf_pda_recruits_title", "Today's recruits"))
+        for s = 1, RECRUIT_ROWS do
+            table.insert(lines, recruits[s] ~= nil and formatRecruitLine(recruits[s]) or "")
         end
+    else
+        table.insert(lines, tr("wc_rf_pda_no_recruits", "No recruits today"))
     end
 
-    return table.concat(lines, "\n"), showingClause
+    while #lines > LIST_MAX_LINES do
+        table.remove(lines)
+    end
+
+    return lines, showingClause
 end
 
-local function seedSubnav(container)
-    -- RESTORE: seed left page MTO once; never setState(..., true).
-    if _subnavSeeded then
-        return
+--- BUILD 12:05 (George CLOSED DESIGN 09:45): one declared Text per roster row (wcRosterRow1..14,
+--- 460x22, one line, clip no wrap) at the same page Ys as the Hire / Fire chips, so a button
+--- always sits on the row it acts on. Rows past the end of lines are blanked.
+local function paintRosterRows(container, lines)
+    lines = lines or {}
+    for i = 1, LIST_MAX_LINES do
+        setText(findDescendant(container, "wcRosterRow" .. i), lines[i] or "")
     end
-    local page = getHostPage()
-    local sel = getPageSelector(container)
-    if sel == nil then
-        return
-    end
-    sel.disableButtonsOnSingleText = false
-    sel.hideLeftRightButtons = false
-    if sel.setVisible then
-        sel:setVisible(true)
-    end
-    if sel.setCanChangeState then
-        sel:setCanChangeState(true)
-    end
-    if sel.setDisabled then
-        sel:setDisabled(false)
-    end
-    local texts = {
-        tr("wc_rf_pda_page_dashboard", "Dashboard"),
-        tr("wc_rf_pda_page_wages", "Wages"),
-        tr("wc_rf_pda_page_workers", "Workers"),
-    }
-    local idx = clampPageIndex(page and page.wcSubPageIndex)
-    if page ~= nil then
-        page.wcSubPageIndex = idx
-        page._wcWageRefreshing = true
-        page._wcSubnavSeeding = true
-    end
-    if sel.setTexts then
-        sel:setTexts(texts)
-    end
-    if sel.setState then
-        sel:setState(idx, false)
-    end
-    if sel.updateAbsolutePosition then
-        sel:updateAbsolutePosition()
-    end
-    if page ~= nil then
-        page._wcSubnavSeeding = false
-        page._wcWageRefreshing = false
-        page._wcSubnavSeeded = true
-        if page._ensureWcSubnavArrowsVisible then
-            page:_ensureWcSubnavArrowsVisible()
-        end
-        if page._syncWcSubPageVisibility then
-            page:_syncWcSubPageVisibility()
-        end
-    end
-    _subnavSeeded = true
 end
+
+--- The twelve declared buttons: Fire i shows when crew row i carries a worker with a uuid, Hire s
+--- when recruit row s carries a recruit. Everything hidden when the roster is not authoritative
+--- (snap nil). Text is set on show only; RF_FwPagerBtn has no inputAction, so no key chip.
+local function paintRosterButtons(container, snap)
+    local workers = (snap and snap.workers) or {}
+    local recruits = (snap and snap.recruits) or {}
+    for i = 1, CREW_ROWS do
+        local el = findDescendant(container, "wcBtnFire" .. i)
+        local w = workers[i]
+        local on = snap ~= nil and w ~= nil and w.uuid ~= nil
+        setVis(el, on)
+        if on then
+            setChipBtn(el, tr("wc_rf_pda_btn_fire", "Fire"), true, false)
+        end
+    end
+    for s = 1, RECRUIT_ROWS do
+        local el = findDescendant(container, "wcBtnHire" .. s)
+        local on = snap ~= nil and recruits[s] ~= nil
+        setVis(el, on)
+        if on then
+            setChipBtn(el, tr("wc_rf_pda_btn_hire", "Hire"), true, false)
+        end
+    end
+end
+
+-- BUILD 18:26: seedSubnav (the three-page picker seed) is gone; wcSubnavSelector stays hidden.
 
 local function paintDashboard(container, lightOnly)
     local mgr = getMgr()
@@ -376,26 +437,17 @@ local function paintDashboard(container, lightOnly)
         else
             setTextColor(statusEl, 1.0, 0.35, 0.35, 1)
         end
-        setText(findDescendant(container, "wcDashMode"),
-            labeled(tr("wc_label_cost_mode", "Cost Mode"), settings:getCostModeName()))
-        setText(findDescendant(container, "wcDashWage"),
-            labeled(tr("wc_label_wage_level", "Wage Level"), settings:getWageLevelName()))
-        local rate = settings:getWageRate()
-        local rateText = settings.costMode == Settings.COST_MODE_HOURLY
-            and (formatMoney(rate) .. " / h") or (formatMoney(rate) .. " / ha")
-        setText(findDescendant(container, "wcDashRate"),
-            labeled(tr("wc_label_current_rate", "Rate"), rateText))
+        -- BUILD 18:26: mode, wage level and rate are carried by the wage MTOs and wcWageBigRate on
+        -- the same page now (wcDashMode / wcDashWage / wcDashRate are gone from the door XML).
     end
 
     local workers = ws:getActiveWorkers()
     local workerCount = #workers
-    local namesEl = findDescendant(container, "wcDashWorkerNames")
 
     if not auth then
         setText(findDescendant(container, "wcDashWorkers"),
             labeled(tr("wc_label_active_workers", "Active Workers"), awaitingSyncText()))
         setText(findDescendant(container, "wcDashEstimate"), awaitingSyncText())
-        setText(namesEl, awaitingSyncText())
     else
         setText(findDescendant(container, "wcDashWorkers"),
             labeled(tr("wc_label_active_workers", "Active Workers"), tostring(workerCount)))
@@ -412,28 +464,8 @@ local function paintDashboard(container, lightOnly)
         setText(findDescendant(container, "wcDashEstimate"),
             string.format(tr("wc_rf_pda_month_est", "Month: %s · Est: %s"),
                 formatMoney(monthAccrued), formatMoney(est)))
-
-        -- Stage-7: on-the-clock names only (full roster lives on Workers).
-        if workerCount > 0 then
-            local names = {}
-            local roster = mgr.workerRoster
-            for _, w in ipairs(workers) do
-                local label = w.name
-                if w.vehicleName ~= nil and w.vehicleName ~= w.name then
-                    label = string.format("%s (%s)", w.name, w.vehicleName)
-                end
-                if roster then
-                    local rw = roster:getWorkerByVehicle(tostring(w.vehicle))
-                    if rw and WorkerRoster and WorkerRoster.levelName then
-                        label = string.format("[%s] %s", WorkerRoster.levelName(rw.level), label)
-                    end
-                end
-                table.insert(names, label)
-            end
-            setText(namesEl, table.concat(names, "\n"))
-        else
-            setText(namesEl, tr("wc_no_workers", "No active workers"))
-        end
+        -- BUILD 18:26: the on-the-clock names list (wcDashWorkerNames) is gone; the full roster
+        -- sits on the same page in the wcRosterRow1..14 texts (paintWorkers).
     end
 
     local remaining = 0
@@ -541,10 +573,8 @@ local function syncWageWidgets(container)
                 "Per hectare: billed by area worked since last settle. Wage Level sets the rate. Settles at midnight.")
                 .. "\n" .. escPays)
     end
-    local resetBtn = findDescendant(container, "wcBtnWageReset")
-    if resetBtn and resetBtn.setText then
-        resetBtn:setText(tr("button_reset", "Reset"))
-    end
+    -- BUILD 00:06: Reset is an overlay chip (RF_CsPivotBtn, no SPACE); the label rides the chip.
+    setChipBtn(findDescendant(container, "wcBtnWageReset"), tr("button_reset", "Reset"), true, false)
 
     if page ~= nil then
         page._wcWageRefreshing = false
@@ -609,8 +639,9 @@ end
 local function paintWorkers(container, lightOnly)
     local mgr = getMgr()
     if mgr == nil or mgr.settings == nil or mgr.workerSystem == nil then
-        setText(findDescendant(container, "wcStatsWorkerList"),
-            tr("wc_rf_pda_empty", "Worker Costs is not ready yet."))
+        paintRosterRows(container, { tr("wc_rf_pda_empty", "Worker Costs is not ready yet.") })
+        _lastSnap = nil
+        paintRosterButtons(container, nil)
         return
     end
     local settings = mgr.settings
@@ -618,14 +649,7 @@ local function paintWorkers(container, lightOnly)
     local snap = getRosterSnap(mgr)
     local auth = isAuthoritative(snap)
 
-    if not lightOnly then
-        setText(findDescendant(container, "wcStatsMode"),
-            labeled(tr("wc_label_cost_mode", "Cost Mode"), settings:getCostModeName()))
-        setText(findDescendant(container, "wcStatsWage"),
-            labeled(tr("wc_label_wage_level", "Wage Level"), settings:getWageLevelName()))
-    end
-
-    local listEl = findDescendant(container, "wcStatsWorkerList")
+    -- BUILD 18:26: wcStatsMode / wcStatsWage are gone; the wage MTOs on the same page carry them.
     local rate = settings:getWageRate()
     local intervalHrs = (WorkerSystem and WorkerSystem.BILLED_HOURS_PER_DAY) or 0.5
     local isHourly = (settings.costMode == Settings.COST_MODE_HOURLY)
@@ -641,7 +665,9 @@ local function paintWorkers(container, lightOnly)
             labeled(tr("wc_label_cost_per_worker", "Cost / Worker"), "-"))
         setText(findDescendant(container, "wcStatsTotal"),
             labeled(tr("wc_label_total_interval_cost", "Total Interval"), "-"))
-        setText(listEl, awaitingSyncText())
+        paintRosterRows(container, { awaitingSyncText() })
+        _lastSnap = nil
+        paintRosterButtons(container, nil)
         return
     end
 
@@ -657,7 +683,7 @@ local function paintWorkers(container, lightOnly)
     if workingN > 0 then
         countText = countText .. string.format(tr("wc_rf_pda_crew_working", " · %d working"), workingN)
     end
-    local listText, showingClause = buildWorkersListText(snap)
+    local listLines, showingClause = buildWorkersListText(snap)
     if showingClause ~= nil then
         countText = countText .. " · " .. showingClause
     end
@@ -684,7 +710,43 @@ local function paintWorkers(container, lightOnly)
             labeled(tr("wc_label_total_interval_cost", "Total Interval"), "-"))
     end
 
-    setText(listEl, listText)
+    paintRosterRows(container, listLines)
+    _lastSnap = snap
+    paintRosterButtons(container, snap)
+end
+
+--- BUILD 22:42 (George CLOSED DESIGN 21:26): Hire / Fire from the Esc page. n is the roster ROW of
+--- the last paint: recruits[n] (rows 11-14, wcBtnHire1..4) or workers[n] (rows 1-8, wcBtnFire1..8).
+--- WorkerManager:hireWorker(slot, farmId) / fireWorker(uuid, farmId) are the thin WCNetwork_SendCommand
+--- wrappers (SP and MP, src/WorkerManager.lua); farmId nil = the local farm inside them. The server
+--- enforces the daily hire limit and the roster snapshot comes back on its own, so the repaint here
+--- is a courtesy and the 500ms tick shows the result. Assign / unassign stay off Esc (no vehicle).
+---@param container table|nil rfHostPlaceholder from the host
+---@param n number recruit row 1..4
+function WcRfPdaGuest.onHire(container, n)
+    local mgr = getMgr()
+    local snap = _lastSnap
+    local r = snap ~= nil and snap.recruits ~= nil and snap.recruits[tonumber(n) or 0] or nil
+    if mgr == nil or type(mgr.hireWorker) ~= "function" or r == nil then
+        return
+    end
+    pcall(mgr.hireWorker, mgr, tonumber(r.slot) or 1, nil)
+    paintDashboard(container, true)
+    paintWorkers(container, true)
+end
+
+---@param container table|nil rfHostPlaceholder from the host
+---@param n number crew row 1..8
+function WcRfPdaGuest.onFire(container, n)
+    local mgr = getMgr()
+    local snap = _lastSnap
+    local w = snap ~= nil and snap.workers ~= nil and snap.workers[tonumber(n) or 0] or nil
+    if mgr == nil or type(mgr.fireWorker) ~= "function" or w == nil or w.uuid == nil then
+        return
+    end
+    pcall(mgr.fireWorker, mgr, w.uuid, nil)
+    paintDashboard(container, true)
+    paintWorkers(container, true)
 end
 
 ---@param container table|nil rfHostPlaceholder from Soil RfPdaMenuPage
@@ -693,14 +755,12 @@ function WcRfPdaGuest.onShow(container, lightOnly)
     -- Placement polish: page hero is Soil rfPageTitle/rfPageBlurb only - do not second-paint host title/blurb.
     setText(findDescendant(container, "rfHostBody"), "")
 
-    -- Seed only when missing (arrow path must never re-seed / forceEvent).
-    if not _subnavSeeded then
-        seedSubnav(container)
-    end
-
+    -- BUILD 18:26 (George CLOSED DESIGN 17:59): one page. No subnav seed (the picker is gone,
+    -- wcSubnavSelector stays hidden); the page index is pinned to the merged Dashboard.
     local page = getHostPage()
     if page ~= nil then
-        page.wcSubPageIndex = clampPageIndex(page.wcSubPageIndex)
+        page.wcSubPageIndex = PAGE_DASHBOARD
+        page._wcSubnavSeeded = true
     end
     if page ~= nil and page._syncWcSubPageVisibility then
         page:_syncWcSubPageVisibility()
@@ -712,6 +772,8 @@ function WcRfPdaGuest.onShow(container, lightOnly)
     setVis(findDescendant(container, "wcSideVersion"), false)
     setVis(findDescendant(container, "wcPageAbout"), false)
     paintSideInfo(container)
+    -- BUILD 00:06: idempotent draw wrap for the Reset / Hire / Fire chips.
+    wireWcChipPaint(container)
 
     local idx = getPageIndex(container)
     -- George: first show of a page = full paint; 500ms tick on same page stays light.
@@ -722,15 +784,14 @@ function WcRfPdaGuest.onShow(container, lightOnly)
         page._wcLastFullPaintPage = idx
     end
 
-    if idx == PAGE_WAGES then
-        if fullPaint then
-            syncWageWidgets(container)
-        end
-    elseif idx == PAGE_WORKERS then
-        paintWorkers(container, not fullPaint)
-    else
-        paintDashboard(container, not fullPaint)
+    -- Merged page: the wage widgets sync on the full paint only (same ids, forceEvent=false,
+    -- calls _ensureWcWageArrowsVisible); the stats and the roster repaint on every tick with
+    -- lightOnly = live numbers only.
+    if fullPaint then
+        syncWageWidgets(container)
     end
+    paintDashboard(container, not fullPaint)
+    paintWorkers(container, not fullPaint)
 end
 
 function WcRfPdaGuest.onHide()
@@ -830,6 +891,11 @@ function WcRfPdaGuest.tryRegister()
     if g_currentMission ~= nil and g_wcGui ~= nil then
         g_currentMission.rfWcGui = g_wcGui
     end
+    -- BUILD 22:42: the guest handle on the mission is the belt for the host Hire / Fire
+    -- forwarders (registry field first, this second), the same channel NPC Favor and Market use.
+    if g_currentMission ~= nil then
+        g_currentMission.WcRfPdaGuest = WcRfPdaGuest
+    end
 
     -- Equal Option B: WC may create menuRealisticFarming when Soil absent.
     -- Always ensureDoor when bootstrap class is sourced; never trust bare (WorkerCostsModDirectory or g_currentModDirectory) at callback time.
@@ -865,7 +931,7 @@ function WcRfPdaGuest.tryRegister()
             id = PANEL_ID,
             title = tr("wc_rf_pda_module_title", "Worker Costs"),
             blurb = tr("wc_rf_pda_blurb",
-                "Wage mode, active workers, next settlement estimate. Open Worker Manager for hire and settings."),
+                "Wage mode, active workers, next settlement estimate. Hire and fire here; assign on Farm Tablet."),
             order = PANEL_ORDER,
             isAvailable = function()
                 return getMgr() ~= nil
@@ -874,6 +940,9 @@ function WcRfPdaGuest.tryRegister()
             onHide = WcRfPdaGuest.onHide,
             onWageOptionChanged = WcRfPdaGuest.onWageOptionChanged,
             onWageReset = WcRfPdaGuest.onWageReset,
+            -- BUILD 22:42: carried by RfEscModules.registerModule from this build on.
+            onHire = WcRfPdaGuest.onHire,
+            onFire = WcRfPdaGuest.onFire,
         })
         if ok then
             _registered = true

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -80,7 +80,7 @@
                  Must use RF_WcSubnavShell (top-left); profile-less GuiElement defaults bottom-left and falls off-screen. -->
             <GuiElement profile="RF_WcSubnavShell" id="wcSubnavShell" visible="false">
                 <MultiTextOption profile="RF_WcSubnavSelector" id="wcSubnavSelector"
-                                 disableButtonsOnSingleText="false"
+                                 disableButtonsOnSingleText="false" visible="false"
                                  onClick="onClickWcSubnavSelector"/>
                 <BoxLayout profile="RF_WcSubnavDotBox" id="wcSubnavDotBox" visible="false">
                     <RoundCorner profile="fs25_subCategorySelectorDot"/>
@@ -405,7 +405,7 @@
                         <GuiElement profile="RF_EscCardFrame" id="soilResistanceCard" position="10px -270px" size="1130px 136px" visible="false">
                             <Text profile="RF_ProductsTitle" id="soilResistanceTitle" position="10px -10px" size="150px 18px"/>
                             <Text profile="RF_HintText" id="soilResistanceState" position="170px -11px" size="820px 20px"/>
-                            <Button profile="RF_FwPagerBtn" id="soilResistancePairsBtn" position="1000px -10px" size="120px 20px"
+                            <Button profile="RF_CsPivotBtn" id="soilResistancePairsBtn" position="1000px -10px" size="120px 20px" handleFocus="false"
                                     text="" onClick="onClickSoilResistancePairs"/>
                             <Bitmap profile="RF_EscCardRule" id="soilResistanceRule" position="10px -35px" size="1110px 1px"/>
                             <Text profile="RF_ProductColHeaderDense" id="soilResMode1Head" position="10px -46px" size="150px 14px"/>
@@ -454,82 +454,122 @@
 
                     <!-- Worker Costs page bodies only (page chrome = left sibling band). -->
                     <GuiElement profile="RF_WcPageShell" id="wcPageShell" visible="false">
-                        <!-- Dashboard -->
-                        <!-- Dashboard is the only WC page that gets the white card (Ash 15:35 #2):
-                             Wages/Workers/About carry MTOs and their own chrome. Framed on
-                             wcPageDashboard itself, not a new inner shell, so nothing double-frames.
-                             Body cells inset 10px L/R and 8px down; worker names still 280 tall and
-                             end at -488 of 500, so 12px of bottom air and no clip. -->
-                        <GuiElement profile="RF_EscCardFrameWide" id="wcPageDashboard" visible="true">
-                            <Text profile="RF_TreatTargetLine" id="wcDashStatus" position="10px -8px" size="1120px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashMode" position="10px -56px" size="550px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashWage" position="580px -56px" size="550px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashRate" position="10px -104px" size="550px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashWorkers" position="580px -104px" size="550px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashEstimate" position="10px -152px" size="550px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashCountdown" position="580px -152px" size="550px 22px" text=""/>
-                            <Text profile="RF_HintText" id="wcDashWorkerNames" position="10px -208px" size="1120px 280px"
-                                  textMaxNumLines="12" textVerticalAlignment="top" text=""/>
-                        </GuiElement>
-
-                        <!-- Wages: tight label+option rows; summary/help/Reset UNDER stack (no 760 side column). -->
-                        <!-- Two cards, not one: settings stack up, summary/help/Reset below, 16px of
-                             clear air between the strokes. The page itself stays unframed - a frame on
-                             RF_WcPage would be the mega-shell over the MTOs George vetoed. Wrappers carry
-                             handleFocus=false so nothing between the player and an option can take a click,
-                             and the MTOs are still found by getDescendantById, which does not care how deep
-                             they sit. Card B trims one internal gap by 8px, which is exactly what the two
-                             strokes plus their air cost, so wcBtnWageReset lands back on -536 and the page
-                             stays 580 tall. Nothing grew to make room. -->
-                        <GuiElement profile="RF_WcPage" id="wcPageWages" size="1140px 580px" visible="false">
-                            <GuiElement profile="RF_EscCardFrameWide" id="wcWagesCardA" position="0px 0px" size="1140px 326px" handleFocus="false">
+                        <!-- Dashboard / Wages / Workers on ONE page (BUILD 18:26, George CLOSED DESIGN 17:59): two
+                             columns, four inner cards, the page itself unframed (a frame on RF_WcPage would be the
+                             mega-shell over the MTOs George vetoed). Left: Card A = the six wage MTO rows, positions
+                             unchanged, onClickWcWageOption, disableButtonsOnSingleText=false; Card B = rate, help, Reset.
+                             Right: Card C = eight live stats; Card D = the roster (fixed Text rows, no SmoothList).
+                             wcPageWages / wcPageWorkers stay declared as empty hidden shells for nil-safe ids; the page
+                             picker wcSubnavSelector is hidden. Cards carry handleFocus=false so nothing between the
+                             player and an option can take a click. -->
+                        <GuiElement profile="RF_WcPage" id="wcPageDashboard" size="1140px 580px" visible="true">
+                            <GuiElement profile="RF_EscCardFrameWide" id="wcWagesCardA" position="0px 0px" size="650px 326px" handleFocus="false">
                                 <Text profile="RF_TreatTargetLine" id="wcWageLblEnabled" position="10px -10px" size="200px 22px" text=""/>
-                                <MultiTextOption profile="RF_WcWageOption" id="wcOptEnabled" position="230px -18px"
-                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptEnabled" position="230px -18px" size="360px 40px"
+                                                 anchors="0 0 1 1" pivot="0 1" disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
                                 <Text profile="RF_TreatTargetLine" id="wcWageLblMode" position="10px -62px" size="200px 22px" text=""/>
-                                <MultiTextOption profile="RF_WcWageOption" id="wcOptCostMode" position="230px -70px"
-                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptCostMode" position="230px -70px" size="360px 40px"
+                                                 anchors="0 0 1 1" pivot="0 1" disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
                                 <Text profile="RF_TreatTargetLine" id="wcWageLblLevel" position="10px -114px" size="200px 22px" text=""/>
-                                <MultiTextOption profile="RF_WcWageOption" id="wcOptWageLevel" position="230px -122px"
-                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptWageLevel" position="230px -122px" size="360px 40px"
+                                                 anchors="0 0 1 1" pivot="0 1" disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
                                 <Text profile="RF_TreatTargetLine" id="wcWageLblNotify" position="10px -166px" size="200px 22px" text=""/>
-                                <MultiTextOption profile="RF_WcWageOption" id="wcOptNotifications" position="230px -174px"
-                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptNotifications" position="230px -174px" size="360px 40px"
+                                                 anchors="0 0 1 1" pivot="0 1" disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
                                 <Text profile="RF_TreatTargetLine" id="wcWageLblDebug" position="10px -218px" size="200px 22px" text=""/>
-                                <MultiTextOption profile="RF_WcWageOption" id="wcOptDebugMode" position="230px -226px"
-                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptDebugMode" position="230px -226px" size="360px 40px"
+                                                 anchors="0 0 1 1" pivot="0 1" disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
                                 <Text profile="RF_TreatTargetLine" id="wcWageLblSalary" position="10px -270px" size="200px 22px" text=""/>
-                                <MultiTextOption profile="RF_WcWageOption" id="wcOptMonthlySalary" position="230px -278px"
-                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptMonthlySalary" position="230px -278px" size="360px 40px"
+                                                 anchors="0 0 1 1" pivot="0 1" disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
                             </GuiElement>
-                            <GuiElement profile="RF_EscCardFrameWide" id="wcWagesCardB" position="0px -342px" size="1140px 238px" handleFocus="false">
-                                <Text profile="RF_SectionTitle" id="wcWageBigRate" position="10px -6px" size="1120px 36px" text=""/>
-                                <Text profile="RF_TreatTargetLine" id="wcWageRateLabel" position="10px -50px" size="550px 22px" text=""/>
-                                <Text profile="RF_TreatTargetLine" id="wcWagePayInterval" position="580px -50px" size="550px 22px" text=""/>
-                                <Text profile="RF_HintText" id="wcWageHelpBody" position="10px -86px" size="1120px 100px"
+                            <GuiElement profile="RF_EscCardFrameWide" id="wcWagesCardB" position="0px -342px" size="650px 238px" handleFocus="false">
+                                <Text profile="RF_SectionTitle" id="wcWageBigRate" position="10px -6px" size="630px 36px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcWageRateLabel" position="10px -50px" size="300px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcWagePayInterval" position="320px -50px" size="320px 22px" text=""/>
+                                <Text profile="RF_HintText" id="wcWageHelpBody" position="10px -86px" size="630px 100px"
                                       textMaxNumLines="4" textVerticalAlignment="top" text=""/>
-                                <Button profile="buttonActivate" id="wcBtnWageReset" position="10px -194px" size="200px 36px"
-                                        text="Reset" onClick="onClickWcWageReset"/>
+                                <Button profile="RF_CsPivotBtn" id="wcBtnWageReset" position="10px -194px" size="200px 36px" handleFocus="false"
+                                        text="" onClick="onClickWcWageReset"/>
                             </GuiElement>
+                            <GuiElement profile="RF_EscCardFrameWide" id="wcWorkersCardA" position="660px 0px" size="480px 240px" handleFocus="false">
+                                <Text profile="RF_TreatTargetLine" id="wcDashStatus" position="10px -10px" size="220px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcDashWorkers" position="250px -10px" size="220px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcDashCountdown" position="10px -58px" size="220px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcStatsInterval" position="250px -58px" size="220px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcStatsCostPer" position="10px -106px" size="220px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcStatsTotal" position="250px -106px" size="220px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcDashEstimate" position="10px -154px" size="460px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcStatsCount" position="10px -202px" size="460px 22px" text=""/>
+                            </GuiElement>
+                            <GuiElement profile="RF_EscCardFrameWide" id="wcWorkersCardB" position="660px -256px" size="480px 324px" handleFocus="false">
+                                <!-- BUILD 12:05 (George CLOSED DESIGN 09:45): fourteen declared row Texts on the chip Ys (page-rel
+                                     -266 .. -549; this card sits at -256), 460x22, 17px, one line each (clip, no wrap), so Hire /
+                                     Fire sit on the same rows as the names. Rows 1-8 crew, 9 blank, 10 title, 11-14 recruits. -->
+                                <Text profile="RF_HintText" id="wcRosterRow1" position="10px -10px" size="460px 22px" textSize="17px"
+                                      textMaxNumLines="1" textVerticalAlignment="middle" text=""/>
+                                <Text profile="RF_HintText" id="wcRosterRow2" position="10px -32px" size="460px 22px" textSize="17px"
+                                      textMaxNumLines="1" textVerticalAlignment="middle" text=""/>
+                                <Text profile="RF_HintText" id="wcRosterRow3" position="10px -53px" size="460px 22px" textSize="17px"
+                                      textMaxNumLines="1" textVerticalAlignment="middle" text=""/>
+                                <Text profile="RF_HintText" id="wcRosterRow4" position="10px -75px" size="460px 22px" textSize="17px"
+                                      textMaxNumLines="1" textVerticalAlignment="middle" text=""/>
+                                <Text profile="RF_HintText" id="wcRosterRow5" position="10px -97px" size="460px 22px" textSize="17px"
+                                      textMaxNumLines="1" textVerticalAlignment="middle" text=""/>
+                                <Text profile="RF_HintText" id="wcRosterRow6" position="10px -118px" size="460px 22px" textSize="17px"
+                                      textMaxNumLines="1" textVerticalAlignment="middle" text=""/>
+                                <Text profile="RF_HintText" id="wcRosterRow7" position="10px -140px" size="460px 22px" textSize="17px"
+                                      textMaxNumLines="1" textVerticalAlignment="middle" text=""/>
+                                <Text profile="RF_HintText" id="wcRosterRow8" position="10px -162px" size="460px 22px" textSize="17px"
+                                      textMaxNumLines="1" textVerticalAlignment="middle" text=""/>
+                                <Text profile="RF_HintText" id="wcRosterRow9" position="10px -184px" size="460px 22px" textSize="17px"
+                                      textMaxNumLines="1" textVerticalAlignment="middle" text=""/>
+                                <Text profile="RF_HintText" id="wcRosterRow10" position="10px -206px" size="460px 22px" textSize="17px"
+                                      textMaxNumLines="1" textVerticalAlignment="middle" text=""/>
+                                <Text profile="RF_HintText" id="wcRosterRow11" position="10px -227px" size="460px 22px" textSize="17px"
+                                      textMaxNumLines="1" textVerticalAlignment="middle" text=""/>
+                                <Text profile="RF_HintText" id="wcRosterRow12" position="10px -249px" size="460px 22px" textSize="17px"
+                                      textMaxNumLines="1" textVerticalAlignment="middle" text=""/>
+                                <Text profile="RF_HintText" id="wcRosterRow13" position="10px -271px" size="460px 22px" textSize="17px"
+                                      textMaxNumLines="1" textVerticalAlignment="middle" text=""/>
+                                <Text profile="RF_HintText" id="wcRosterRow14" position="10px -293px" size="460px 22px" textSize="17px"
+                                      textMaxNumLines="1" textVerticalAlignment="middle" text=""/>
+                            </GuiElement>
+                            <!-- BUILD 22:42 (George CLOSED DESIGN 21:26, Ash 22:42): Hire / Fire on this page. Twelve declared
+                                 RF_FwPagerBtn buttons (no inputAction, mouse only, handleFocus=false), page-relative, right of the
+                                 roster text column (x 1060-1130): wcBtnFire1..8 on crew rows 1-8, wcBtnHire1..4 on recruit rows
+                                 11-14 (WcRfPdaGuest pins the recruit block there). Hidden by default; the guest shows one only
+                                 when that row carries a worker / recruit and hides all of them when the roster is not
+                                 authoritative. Clicks go to the host forwarders onClickWcFireN / onClickWcHireN, which reach
+                                 the guest through the registry (onFire / onHire). Assign / unassign stay on Farm Tablet. -->
+                            <Button profile="RF_CsPivotBtn" id="wcBtnFire1" position="1060px -266px" size="70px 20px" visible="false"
+                                    handleFocus="false" text="" onClick="onClickWcFire1"/>
+                            <Button profile="RF_CsPivotBtn" id="wcBtnFire2" position="1060px -288px" size="70px 20px" visible="false"
+                                    handleFocus="false" text="" onClick="onClickWcFire2"/>
+                            <Button profile="RF_CsPivotBtn" id="wcBtnFire3" position="1060px -309px" size="70px 20px" visible="false"
+                                    handleFocus="false" text="" onClick="onClickWcFire3"/>
+                            <Button profile="RF_CsPivotBtn" id="wcBtnFire4" position="1060px -331px" size="70px 20px" visible="false"
+                                    handleFocus="false" text="" onClick="onClickWcFire4"/>
+                            <Button profile="RF_CsPivotBtn" id="wcBtnFire5" position="1060px -353px" size="70px 20px" visible="false"
+                                    handleFocus="false" text="" onClick="onClickWcFire5"/>
+                            <Button profile="RF_CsPivotBtn" id="wcBtnFire6" position="1060px -374px" size="70px 20px" visible="false"
+                                    handleFocus="false" text="" onClick="onClickWcFire6"/>
+                            <Button profile="RF_CsPivotBtn" id="wcBtnFire7" position="1060px -396px" size="70px 20px" visible="false"
+                                    handleFocus="false" text="" onClick="onClickWcFire7"/>
+                            <Button profile="RF_CsPivotBtn" id="wcBtnFire8" position="1060px -418px" size="70px 20px" visible="false"
+                                    handleFocus="false" text="" onClick="onClickWcFire8"/>
+                            <Button profile="RF_CsPivotBtn" id="wcBtnHire1" position="1060px -483px" size="70px 20px" visible="false"
+                                    handleFocus="false" text="" onClick="onClickWcHire1"/>
+                            <Button profile="RF_CsPivotBtn" id="wcBtnHire2" position="1060px -505px" size="70px 20px" visible="false"
+                                    handleFocus="false" text="" onClick="onClickWcHire2"/>
+                            <Button profile="RF_CsPivotBtn" id="wcBtnHire3" position="1060px -527px" size="70px 20px" visible="false"
+                                    handleFocus="false" text="" onClick="onClickWcHire3"/>
+                            <Button profile="RF_CsPivotBtn" id="wcBtnHire4" position="1060px -549px" size="70px 20px" visible="false"
+                                    handleFocus="false" text="" onClick="onClickWcHire4"/>
                         </GuiElement>
-
-                        <!-- Workers -->
-                        <!-- Same family as Wages: stats card, 16px of air, then the worker list card.
-                             wcStatsWorkerList stays fixed Text rows, no SmoothList. -->
-                        <GuiElement profile="RF_WcPage" id="wcPageWorkers" visible="false">
-                            <GuiElement profile="RF_EscCardFrameWide" id="wcWorkersCardA" position="0px 0px" size="1140px 136px" handleFocus="false">
-                                <Text profile="RF_TreatTargetLine" id="wcStatsMode" position="10px -10px" size="550px 22px" text=""/>
-                                <Text profile="RF_TreatTargetLine" id="wcStatsWage" position="580px -10px" size="550px 22px" text=""/>
-                                <Text profile="RF_TreatTargetLine" id="wcStatsInterval" position="10px -58px" size="550px 22px" text=""/>
-                                <Text profile="RF_TreatTargetLine" id="wcStatsCount" position="580px -58px" size="550px 22px" text=""/>
-                                <Text profile="RF_TreatTargetLine" id="wcStatsCostPer" position="10px -106px" size="550px 22px" text=""/>
-                                <Text profile="RF_TreatTargetLine" id="wcStatsTotal" position="580px -106px" size="550px 22px" text=""/>
-                            </GuiElement>
-                            <GuiElement profile="RF_EscCardFrameWide" id="wcWorkersCardB" position="0px -152px" size="1140px 338px" handleFocus="false">
-                                <Text profile="RF_HintText" id="wcStatsWorkerList" position="10px -10px" size="1120px 320px"
-                                      textMaxNumLines="14" textVerticalAlignment="top" text=""/>
-                            </GuiElement>
-                        </GuiElement>
+                        <!-- Empty hidden shells: the ids stay declared for nil-safe lookups (host page sync). -->
+                        <GuiElement profile="RF_WcPage" id="wcPageWages" size="1140px 580px" visible="false"/>
+                        <GuiElement profile="RF_WcPage" id="wcPageWorkers" visible="false"/>
 
                         <!-- About page retired 2026-08-02: copy lives in wcSideInfoShell. Keep shell for nil-safe ids. -->
                         <GuiElement profile="RF_WcPage" id="wcPageAbout" visible="false">
@@ -569,11 +609,13 @@
                             <Text profile="RF_HintText" id="rfFwHint" position="10px -208px" size="1120px 120px"
                                   textMaxNumLines="4" textVerticalAlignment="top" text=""/>
                         </GuiElement>
-                        <!-- Dairy / NPC Favor table glance. Content runs to -416 (hint under the rows),
-                             so 428 gives the same 12px of bottom air. Only one of the two blocks is
-                             ever visible (setVis is an either/or), so no card is ever naked beside
-                             another - Ash 15:35 #1 sibling framing has nothing to bite on here. -->
-                        <GuiElement profile="RF_EscCardFrameWide" id="rfFwTableBlock" visible="false" position="0px 0px" size="1140px 428px">
+                        <!-- Dairy / NPC Favor / Pro Staff glance bay. BUILD 20:36 (George CLOSED DESIGN 19:03,
+                             Wizard eyes-on): 1140x780 so two 380-tall Dairy cards, a taller NPC row pitch and the
+                             276x124 Pro Staff cards fit. Income / Depot keep their XML rows and hint positions
+                             (grey air below is benign); NPC re-places the shared rows at show time and hands
+                             the XML positions back on the registry change listener. Only one block is ever
+                             visible (setVis is an either/or). -->
+                        <GuiElement profile="RF_EscCardFrameWide" id="rfFwTableBlock" visible="false" position="0px 0px" size="1140px 780px">
                             <Text profile="RF_SectionTitle" id="rfFwTableTitle" position="10px -8px" size="1120px 24px" text="" visible="false"/>
                             <!-- Excel sheet: the outer border is rfFwTableBlock's own hasFrame; these 11 hairlines
                                  are the inner grid. RF_EscCardRule is already blank.png + soft grey 0.55, so they
@@ -628,26 +670,9 @@
                             <Text profile="RF_TreatTargetLine" id="rfFwRow8C" position="610px -264px" size="220px 20px" text=""/>
                             <Text profile="RF_TreatTargetLine" id="rfFwRow8D" position="850px -264px" size="280px 20px" text=""/>
                             <Text profile="RF_TreatTargetLine" id="rfFwMore" position="10px -300px" size="1120px 20px" text=""/>
-                            <!-- BUILD 09:19 (PB-07): row pager for this static eight-row table.
-                                 Hidden by default and shown ONLY by a guest that implements
-                                 onPageStep, so Income / Dairy / Depot keep exactly the page they
-                                 have today. Two Buttons, not a SmoothList: George's standing NO-GO
-                                 on nesting a SmoothList in this page (see csConsultPanel below)
-                                 applies here too, and a window offset held by the guest cannot
-                                 re-enter the layout the way a list rebuild can.
-                                 Parked on the rfFwTableTitle band, which every Table-mode guest
-                                 already hides, so the pager collides with nothing that paints. -->
-                            <!-- 2026-08-22 FAIL-FIX (live screenshot 17:11): bottom-right placement inside
-                                 the 1140x428 table frame was correct and is kept; the profile was not.
-                                 RF_CsPivotBtn inherits inputAction MENU_ACTIVATE from buttonActivate, so the
-                                 engine painted a SPACE key chip on BOTH buttons and each chip pushed its own
-                                 label out of its 120px box into the neighbour. RF_FwPagerBtn extends
-                                 fs25_wideButton instead - identical chrome, no inputAction, so no chip.
-                                 See rfEscProfiles.xml. Page keys: . / > next, , / < back. -->
-                            <Button profile="RF_FwPagerBtn" id="rfFwPagePrev" position="880px -396px" size="120px 24px"
-                                    visible="false" text="" onClick="onClickRfFwPagePrev"/>
-                            <Button profile="RF_FwPagerBtn" id="rfFwPageNext" position="1010px -396px" size="120px 24px"
-                                    visible="false" text="" onClick="onClickRfFwPageNext"/>
+                            <!-- BUILD 00:06 (George CLOSED DESIGN 23:12): the rfFwPagePrev / rfFwPageNext row pager is gone;
+                                 the NPC Favor tables scroll (rfFwRosterList / rfFwFavorList below). The host keyEvent page
+                                 belt (. / , keys) still serves a guest that registers onPageStep (Dairy cards). -->
                             <!-- BUILD 14:35 (Ash 14:35, Wizard: build Buy / Run like the other modules): the
                                  Pro Staff action strip, bottom-left of the same band the pager parks on (the
                                  pager is bottom-right). In EVERY suite door copy from this build on, so the
@@ -658,14 +683,81 @@
                                  into every host RfPdaMenuPage.lua); Buy routes to ProStaffManager:buyLevel
                                  and Run to ProStaffManager:requestFarmFlush, no other money path exists here.
                                  RF_FwPagerBtn: fs25_wideButton chrome, no inputAction, so no key chip. -->
-                            <Button profile="RF_FwPagerBtn" id="rfPsBuyBtn" position="10px -396px" size="240px 24px"
+                            <Button profile="RF_CsPivotBtn" id="rfPsBuyBtn" position="10px -748px" size="240px 24px" handleFocus="false"
                                     visible="false" text="" onClick="onClickPsBuy"/>
-                            <Button profile="RF_FwPagerBtn" id="rfPsFlushBtn" position="260px -396px" size="240px 24px"
+                            <Button profile="RF_CsPivotBtn" id="rfPsFlushBtn" position="260px -748px" size="240px 24px" handleFocus="false"
                                     visible="false" text="" onClick="onClickPsFlush"/>
                             <Text profile="RF_HintText" id="rfFwEmptyHint" position="10px -68px" size="1120px 44px"
                                   textMaxNumLines="2" visible="false" text=""/>
                             <Text profile="RF_HintText" id="rfFwHintTable" position="10px -336px" size="1120px 80px"
                                   textMaxNumLines="3" textVerticalAlignment="top" text=""/>
+                            <!-- BUILD 00:06 (George CLOSED DESIGN 23:12, Ash 00:06): NPC Favor scrollable tables. Two SmoothLists
+                                 under this GuiElement host (rfFwTableBlock is a GuiElement, never a Map Bitmap: the hang fence),
+                                 the same nest as mdCommodityList (ListItem template cloned by the engine, clipper Bitmaps, slider
+                                 box). No runtime element create; reloadData on show only. Hidden by default so Income / Dairy /
+                                 Depot keep the static sheet; NpcRfPdaGuest shows them and hands the sheet back on leave. The ten
+                                 door copies carry them so whichever mod builds the door has the ids. -->
+                            <GuiElement profile="RF_FwListBox" id="rfFwRosterBox" position="10px -68px" size="800px 420px" visible="false">
+                                <SmoothList id="rfFwRosterList" profile="RF_FwRosterList" size="780px 420px" handleFocus="false"
+                                            startClipperElementName="rfFwRosterStart" endClipperElementName="rfFwRosterEnd">
+                                    <ListItem profile="RF_FwRosterItem" height="60px">
+                                        <Bitmap profile="RF_RowBg" name="alternating"/>
+                                        <Text profile="RF_FwListCell" name="rfFwRosterWho" position="0px 0px" size="200px 60px"/>
+                                        <Text profile="RF_FwListCell" name="rfFwRosterStanding" position="210px 0px" size="180px 60px"/>
+                                        <Text profile="RF_FwListCell" name="rfFwRosterBenefits" position="400px 0px" size="180px 60px"/>
+                                        <Text profile="RF_FwListCell" name="rfFwRosterHistory" position="590px 0px" size="210px 60px"/>
+                                    </ListItem>
+                                </SmoothList>
+                                <Bitmap profile="fs25_secondaryMenuStartClipper" name="rfFwRosterStart"/>
+                                <Bitmap profile="fs25_secondaryMenuStopClipper" name="rfFwRosterEnd"/>
+                                <ThreePartBitmap profile="fs25_subCategoryListSliderBox">
+                                    <Slider profile="fs25_listSlider" dataElementId="rfFwRosterList" hideParentWhenEmpty="true"/>
+                                </ThreePartBitmap>
+                            </GuiElement>
+                            <Text profile="RF_FwColHeader" id="rfFwFavColWho" position="10px -500px" size="90px 24px" visible="false" text=""/>
+                            <Text profile="RF_FwColHeader" id="rfFwFavColGroup" position="110px -500px" size="160px 24px" visible="false" text=""/>
+                            <Text profile="RF_FwColHeader" id="rfFwFavColWhat" position="280px -500px" size="400px 24px" visible="false" text=""/>
+                            <Text profile="RF_FwColHeader" id="rfFwFavColUrgency" position="690px -500px" size="120px 24px" visible="false" text=""/>
+                            <GuiElement profile="RF_FwListBox" id="rfFwFavorBox" position="10px -528px" size="800px 224px" visible="false">
+                                <SmoothList id="rfFwFavorList" profile="RF_FwFavorList" size="780px 224px" handleFocus="false"
+                                            startClipperElementName="rfFwFavorStart" endClipperElementName="rfFwFavorEnd">
+                                    <ListItem profile="RF_FwFavorItem" height="32px">
+                                        <Bitmap profile="RF_RowBg" name="alternating"/>
+                                        <Text profile="RF_FwFavCell" name="rfFwFavorWho" position="0px 0px" size="90px 32px"/>
+                                        <Text profile="RF_FwFavCell" name="rfFwFavorGroup" position="100px 0px" size="160px 32px"/>
+                                        <Text profile="RF_FwFavCell" name="rfFwFavorWhat" position="270px 0px" size="400px 32px"/>
+                                        <Text profile="RF_FwFavCell" name="rfFwFavorUrgency" position="680px 0px" size="120px 32px"/>
+                                    </ListItem>
+                                </SmoothList>
+                                <Bitmap profile="fs25_secondaryMenuStartClipper" name="rfFwFavorStart"/>
+                                <Bitmap profile="fs25_secondaryMenuStopClipper" name="rfFwFavorEnd"/>
+                                <ThreePartBitmap profile="fs25_subCategoryListSliderBox">
+                                    <Slider profile="fs25_listSlider" dataElementId="rfFwFavorList" hideParentWhenEmpty="true"/>
+                                </ThreePartBitmap>
+                            </GuiElement>
+                            <Text profile="RF_HintText" id="rfFwFavEmpty" position="10px -528px" size="800px 40px" visible="false" text=""/>
+                            <!-- BUILD 12:05 (George CLOSED DESIGN 09:45): the two detail cards on the right of the 800 lists. A
+                                 SmoothList click selects a row (engine setSelectedItem -> delegate onListSelectionChanged); the
+                                 guest paints the row unclipped here and hides the card on a full show until a row is picked.
+                                 George named rfFwCardWho on both cards; one id per page, so the favor card carries the
+                                 rfFwFavCard* ids. Hidden by default, host-hidden on every refresh, NPC show alone paints. -->
+                            <GuiElement profile="RF_EscCardFrame" id="rfFwRosterDetailCard" position="820px -68px" size="300px 420px" visible="false">
+                                <Text profile="RF_SectionTitle" id="rfFwCardWho" position="10px -10px" size="280px 24px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="rfFwCardStanding" position="10px -42px" size="280px 22px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_FwColHeader" id="rfFwCardBenefitsHead" position="10px -76px" size="280px 22px" text=""/>
+                                <Text profile="RF_HintText" id="rfFwCardBenefits" position="10px -100px" size="280px 176px"
+                                      textMaxNumLines="8" textVerticalAlignment="top" text=""/>
+                                <Text profile="RF_FwColHeader" id="rfFwCardHistoryHead" position="10px -286px" size="280px 22px" text=""/>
+                                <Text profile="RF_HintText" id="rfFwCardHistory" position="10px -310px" size="280px 88px"
+                                      textMaxNumLines="4" textVerticalAlignment="top" text=""/>
+                            </GuiElement>
+                            <GuiElement profile="RF_EscCardFrame" id="rfFwFavorDetailCard" position="820px -528px" size="300px 224px" visible="false">
+                                <Text profile="RF_SectionTitle" id="rfFwFavCardGroup" position="10px -10px" size="280px 24px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="rfFwFavCardWho" position="10px -42px" size="280px 22px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_HintText" id="rfFwFavCardWhat" position="10px -72px" size="280px 110px"
+                                      textMaxNumLines="5" textVerticalAlignment="top" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="rfFwFavCardUrgency" position="10px -190px" size="280px 22px" textMaxNumLines="1" text=""/>
+                            </GuiElement>
                             <!-- BUILD 07:47 (Ash 07:47, George CLOSED DESIGN 07:36): Dairy barn cards, breed tables.
                                  Two 555x380 RF_EscCardFrame cards side by side in the 1140x428 bay (2 per page; the
                                  rfDairyCard3 / rfDairyCard4 frames stay as dark spares so no id disappears from the
@@ -693,8 +785,8 @@
                                       textMaxNumLines="4" textVerticalAlignment="top" textAlignment="right" text=""/>
                                 <Text profile="RF_HintText" id="rfDairyCard1Stored" position="10px -252px" size="535px 60px"
                                       textMaxNumLines="3" textVerticalAlignment="top" text=""/>
-                                <Button profile="RF_FwPagerBtn" id="rfDairyCard1BreedPrev" position="10px -346px" size="120px 24px" visible="false" text=""/>
-                                <Button profile="RF_FwPagerBtn" id="rfDairyCard1BreedNext" position="140px -346px" size="160px 24px" visible="false" text=""/>
+                                <Button profile="RF_CsPivotBtn" id="rfDairyCard1BreedPrev" position="10px -346px" size="120px 24px" handleFocus="false" visible="false" text=""/>
+                                <Button profile="RF_CsPivotBtn" id="rfDairyCard1BreedNext" position="140px -346px" size="160px 24px" handleFocus="false" visible="false" text=""/>
                             </GuiElement>
                             <GuiElement profile="RF_EscCardFrame" id="rfDairyCard2" position="575px -8px" size="555px 380px" visible="false">
                                 <Text profile="RF_SectionTitle" id="rfDairyCard2Name" position="10px -6px" size="535px 24px" text=""/>
@@ -711,10 +803,10 @@
                                       textMaxNumLines="4" textVerticalAlignment="top" textAlignment="right" text=""/>
                                 <Text profile="RF_HintText" id="rfDairyCard2Stored" position="10px -252px" size="535px 60px"
                                       textMaxNumLines="3" textVerticalAlignment="top" text=""/>
-                                <Button profile="RF_FwPagerBtn" id="rfDairyCard2BreedPrev" position="10px -346px" size="120px 24px" visible="false" text=""/>
-                                <Button profile="RF_FwPagerBtn" id="rfDairyCard2BreedNext" position="140px -346px" size="160px 24px" visible="false" text=""/>
+                                <Button profile="RF_CsPivotBtn" id="rfDairyCard2BreedPrev" position="10px -346px" size="120px 24px" handleFocus="false" visible="false" text=""/>
+                                <Button profile="RF_CsPivotBtn" id="rfDairyCard2BreedNext" position="140px -346px" size="160px 24px" handleFocus="false" visible="false" text=""/>
                             </GuiElement>
-                            <GuiElement profile="RF_EscCardFrame" id="rfDairyCard3" position="10px -8px" size="555px 380px" visible="false">
+                            <GuiElement profile="RF_EscCardFrame" id="rfDairyCard3" position="10px -396px" size="555px 380px" visible="false">
                                 <Text profile="RF_SectionTitle" id="rfDairyCard3Name" position="10px -6px" size="535px 24px" text=""/>
                                 <Text profile="RF_HintText" id="rfDairyCard3State" position="10px -32px" size="535px 20px" text=""/>
                                 <Text profile="RF_HintText" id="rfDairyCard3HerdHead" position="10px -52px" size="535px 20px" text=""/>
@@ -729,10 +821,10 @@
                                       textMaxNumLines="4" textVerticalAlignment="top" textAlignment="right" text=""/>
                                 <Text profile="RF_HintText" id="rfDairyCard3Stored" position="10px -252px" size="535px 60px"
                                       textMaxNumLines="3" textVerticalAlignment="top" text=""/>
-                                <Button profile="RF_FwPagerBtn" id="rfDairyCard3BreedPrev" position="10px -346px" size="120px 24px" visible="false" text=""/>
-                                <Button profile="RF_FwPagerBtn" id="rfDairyCard3BreedNext" position="140px -346px" size="160px 24px" visible="false" text=""/>
+                                <Button profile="RF_CsPivotBtn" id="rfDairyCard3BreedPrev" position="10px -346px" size="120px 24px" handleFocus="false" visible="false" text=""/>
+                                <Button profile="RF_CsPivotBtn" id="rfDairyCard3BreedNext" position="140px -346px" size="160px 24px" handleFocus="false" visible="false" text=""/>
                             </GuiElement>
-                            <GuiElement profile="RF_EscCardFrame" id="rfDairyCard4" position="575px -8px" size="555px 380px" visible="false">
+                            <GuiElement profile="RF_EscCardFrame" id="rfDairyCard4" position="575px -396px" size="555px 380px" visible="false">
                                 <Text profile="RF_SectionTitle" id="rfDairyCard4Name" position="10px -6px" size="535px 24px" text=""/>
                                 <Text profile="RF_HintText" id="rfDairyCard4State" position="10px -32px" size="535px 20px" text=""/>
                                 <Text profile="RF_HintText" id="rfDairyCard4HerdHead" position="10px -52px" size="535px 20px" text=""/>
@@ -747,14 +839,16 @@
                                       textMaxNumLines="4" textVerticalAlignment="top" textAlignment="right" text=""/>
                                 <Text profile="RF_HintText" id="rfDairyCard4Stored" position="10px -252px" size="535px 60px"
                                       textMaxNumLines="3" textVerticalAlignment="top" text=""/>
-                                <Button profile="RF_FwPagerBtn" id="rfDairyCard4BreedPrev" position="10px -346px" size="120px 24px" visible="false" text=""/>
-                                <Button profile="RF_FwPagerBtn" id="rfDairyCard4BreedNext" position="140px -346px" size="160px 24px" visible="false" text=""/>
+                                <Button profile="RF_CsPivotBtn" id="rfDairyCard4BreedPrev" position="10px -346px" size="120px 24px" handleFocus="false" visible="false" text=""/>
+                                <Button profile="RF_CsPivotBtn" id="rfDairyCard4BreedNext" position="140px -346px" size="160px 24px" handleFocus="false" visible="false" text=""/>
                             </GuiElement>
-                            <Text profile="RF_HintText" id="rfDairyCardsHint" position="10px -390px" size="860px 36px"
-                                  textMaxNumLines="2" textVerticalAlignment="top" visible="false" text=""/>
+                            <Text profile="RF_HintText" id="rfDairyCardsHint" position="10px -390px" size="860px 80px"
+                                  textMaxNumLines="4" textVerticalAlignment="top" visible="false" text=""/>
                             <!-- BUILD 09:37 (Ash 09:37, George CLOSED DESIGN 09:08): Pro Staff one-page level ladder.
-                                 Header (two lines, y 0 to -44), a 4x5 grid of 270x52 cards (y -48 to -340, 8px gaps)
-                                 and a footer strip (y -344 to -428) above the rfPsBuyBtn / rfPsFlushBtn row at -396.
+                                 Header line 1 at -2 (line 2 declared, hidden since BUILD 17:58: honesty lives in the side
+                                 info), a 4x5 grid of 276x124 cards (y -26 to -726, 20px gaps; BUILD 20:36, Wizard UX,
+                                 type 18 / 16 / 14px) each with a Cost line (rfPsCardNExtra), the recurring line at -726 (the
+                                 Buy / Run result rides it; rfPsNote is gone) above the rfPsBuyBtn / rfPsFlushBtn row at -748.
                                  Each card is a GuiElement frame with a blank-slice Bitmap background (imageColor), a
                                  left marker bar shown only on the rung the farm is at, the rung number, the level
                                  name and a two-line benefit. Every element is hidden by default and only
@@ -765,190 +859,208 @@
                                   textSize="17px" textBold="true" textColor="1 1 1 0.95" textMaxNumLines="1" visible="false" text=""/>
                             <Text profile="RF_HintText" id="rfPsHeaderLine2" position="10px -24px" size="1120px 20px"
                                   textSize="15px" textMaxNumLines="1" visible="false" text=""/>
-                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard1" position="10px -48px" size="270px 52px"
+                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard1" position="10px -26px" size="276px 124px"
                                         frameLeftColor="0.478 0.502 0.533 0.55" frameTopColor="0.478 0.502 0.533 0.55" frameRightColor="0.478 0.502 0.533 0.55" frameBottomColor="0.478 0.502 0.533 0.55" visible="false">
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard1Bg" position="0px 0px" size="270px 52px" imageColor="0.118 0.129 0.141 0.85"/>
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard1Mark" position="0px 0px" size="6px 52px" imageColor="0.549 0.776 0.247 1" visible="false"/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard1Num" position="12px -3px" size="40px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard1Name" position="50px -3px" size="212px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_HintText" id="rfPsCard1Benefit" position="12px -20px" size="252px 32px" textSize="13px"
-                                      textMaxNumLines="2" textVerticalAlignment="top" text=""/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard1Bg" position="0px 0px" size="276px 124px" imageColor="0.118 0.129 0.141 0.85"/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard1Mark" position="0px 0px" size="6px 124px" imageColor="0.549 0.776 0.247 1" visible="false"/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard1Num" position="12px -4px" size="44px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard1Name" position="56px -4px" size="208px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard1Benefit" position="12px -30px" size="252px 58px" textSize="16px"
+                                      textMaxNumLines="3" textVerticalAlignment="top" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard1Extra" position="12px -96px" size="252px 20px" textSize="14px" textMaxNumLines="1" textVerticalAlignment="top" text=""/>
                             </GuiElement>
-                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard2" position="288px -48px" size="270px 52px"
+                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard2" position="288px -26px" size="276px 124px"
                                         frameLeftColor="0.478 0.502 0.533 0.55" frameTopColor="0.478 0.502 0.533 0.55" frameRightColor="0.478 0.502 0.533 0.55" frameBottomColor="0.478 0.502 0.533 0.55" visible="false">
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard2Bg" position="0px 0px" size="270px 52px" imageColor="0.118 0.129 0.141 0.85"/>
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard2Mark" position="0px 0px" size="6px 52px" imageColor="0.549 0.776 0.247 1" visible="false"/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard2Num" position="12px -3px" size="40px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard2Name" position="50px -3px" size="212px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_HintText" id="rfPsCard2Benefit" position="12px -20px" size="252px 32px" textSize="13px"
-                                      textMaxNumLines="2" textVerticalAlignment="top" text=""/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard2Bg" position="0px 0px" size="276px 124px" imageColor="0.118 0.129 0.141 0.85"/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard2Mark" position="0px 0px" size="6px 124px" imageColor="0.549 0.776 0.247 1" visible="false"/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard2Num" position="12px -4px" size="44px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard2Name" position="56px -4px" size="208px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard2Benefit" position="12px -30px" size="252px 58px" textSize="16px"
+                                      textMaxNumLines="3" textVerticalAlignment="top" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard2Extra" position="12px -96px" size="252px 20px" textSize="14px" textMaxNumLines="1" textVerticalAlignment="top" text=""/>
                             </GuiElement>
-                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard3" position="566px -48px" size="270px 52px"
+                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard3" position="566px -26px" size="276px 124px"
                                         frameLeftColor="0.478 0.502 0.533 0.55" frameTopColor="0.478 0.502 0.533 0.55" frameRightColor="0.478 0.502 0.533 0.55" frameBottomColor="0.478 0.502 0.533 0.55" visible="false">
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard3Bg" position="0px 0px" size="270px 52px" imageColor="0.118 0.129 0.141 0.85"/>
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard3Mark" position="0px 0px" size="6px 52px" imageColor="0.549 0.776 0.247 1" visible="false"/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard3Num" position="12px -3px" size="40px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard3Name" position="50px -3px" size="212px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_HintText" id="rfPsCard3Benefit" position="12px -20px" size="252px 32px" textSize="13px"
-                                      textMaxNumLines="2" textVerticalAlignment="top" text=""/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard3Bg" position="0px 0px" size="276px 124px" imageColor="0.118 0.129 0.141 0.85"/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard3Mark" position="0px 0px" size="6px 124px" imageColor="0.549 0.776 0.247 1" visible="false"/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard3Num" position="12px -4px" size="44px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard3Name" position="56px -4px" size="208px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard3Benefit" position="12px -30px" size="252px 58px" textSize="16px"
+                                      textMaxNumLines="3" textVerticalAlignment="top" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard3Extra" position="12px -96px" size="252px 20px" textSize="14px" textMaxNumLines="1" textVerticalAlignment="top" text=""/>
                             </GuiElement>
-                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard4" position="844px -48px" size="270px 52px"
+                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard4" position="844px -26px" size="276px 124px"
                                         frameLeftColor="0.478 0.502 0.533 0.55" frameTopColor="0.478 0.502 0.533 0.55" frameRightColor="0.478 0.502 0.533 0.55" frameBottomColor="0.478 0.502 0.533 0.55" visible="false">
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard4Bg" position="0px 0px" size="270px 52px" imageColor="0.118 0.129 0.141 0.85"/>
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard4Mark" position="0px 0px" size="6px 52px" imageColor="0.549 0.776 0.247 1" visible="false"/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard4Num" position="12px -3px" size="40px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard4Name" position="50px -3px" size="212px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_HintText" id="rfPsCard4Benefit" position="12px -20px" size="252px 32px" textSize="13px"
-                                      textMaxNumLines="2" textVerticalAlignment="top" text=""/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard4Bg" position="0px 0px" size="276px 124px" imageColor="0.118 0.129 0.141 0.85"/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard4Mark" position="0px 0px" size="6px 124px" imageColor="0.549 0.776 0.247 1" visible="false"/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard4Num" position="12px -4px" size="44px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard4Name" position="56px -4px" size="208px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard4Benefit" position="12px -30px" size="252px 58px" textSize="16px"
+                                      textMaxNumLines="3" textVerticalAlignment="top" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard4Extra" position="12px -96px" size="252px 20px" textSize="14px" textMaxNumLines="1" textVerticalAlignment="top" text=""/>
                             </GuiElement>
-                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard5" position="10px -108px" size="270px 52px"
+                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard5" position="10px -170px" size="276px 124px"
                                         frameLeftColor="0.478 0.502 0.533 0.55" frameTopColor="0.478 0.502 0.533 0.55" frameRightColor="0.478 0.502 0.533 0.55" frameBottomColor="0.478 0.502 0.533 0.55" visible="false">
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard5Bg" position="0px 0px" size="270px 52px" imageColor="0.118 0.129 0.141 0.85"/>
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard5Mark" position="0px 0px" size="6px 52px" imageColor="0.549 0.776 0.247 1" visible="false"/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard5Num" position="12px -3px" size="40px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard5Name" position="50px -3px" size="212px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_HintText" id="rfPsCard5Benefit" position="12px -20px" size="252px 32px" textSize="13px"
-                                      textMaxNumLines="2" textVerticalAlignment="top" text=""/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard5Bg" position="0px 0px" size="276px 124px" imageColor="0.118 0.129 0.141 0.85"/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard5Mark" position="0px 0px" size="6px 124px" imageColor="0.549 0.776 0.247 1" visible="false"/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard5Num" position="12px -4px" size="44px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard5Name" position="56px -4px" size="208px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard5Benefit" position="12px -30px" size="252px 58px" textSize="16px"
+                                      textMaxNumLines="3" textVerticalAlignment="top" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard5Extra" position="12px -96px" size="252px 20px" textSize="14px" textMaxNumLines="1" textVerticalAlignment="top" text=""/>
                             </GuiElement>
-                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard6" position="288px -108px" size="270px 52px"
+                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard6" position="288px -170px" size="276px 124px"
                                         frameLeftColor="0.478 0.502 0.533 0.55" frameTopColor="0.478 0.502 0.533 0.55" frameRightColor="0.478 0.502 0.533 0.55" frameBottomColor="0.478 0.502 0.533 0.55" visible="false">
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard6Bg" position="0px 0px" size="270px 52px" imageColor="0.118 0.129 0.141 0.85"/>
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard6Mark" position="0px 0px" size="6px 52px" imageColor="0.549 0.776 0.247 1" visible="false"/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard6Num" position="12px -3px" size="40px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard6Name" position="50px -3px" size="212px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_HintText" id="rfPsCard6Benefit" position="12px -20px" size="252px 32px" textSize="13px"
-                                      textMaxNumLines="2" textVerticalAlignment="top" text=""/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard6Bg" position="0px 0px" size="276px 124px" imageColor="0.118 0.129 0.141 0.85"/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard6Mark" position="0px 0px" size="6px 124px" imageColor="0.549 0.776 0.247 1" visible="false"/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard6Num" position="12px -4px" size="44px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard6Name" position="56px -4px" size="208px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard6Benefit" position="12px -30px" size="252px 58px" textSize="16px"
+                                      textMaxNumLines="3" textVerticalAlignment="top" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard6Extra" position="12px -96px" size="252px 20px" textSize="14px" textMaxNumLines="1" textVerticalAlignment="top" text=""/>
                             </GuiElement>
-                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard7" position="566px -108px" size="270px 52px"
+                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard7" position="566px -170px" size="276px 124px"
                                         frameLeftColor="0.478 0.502 0.533 0.55" frameTopColor="0.478 0.502 0.533 0.55" frameRightColor="0.478 0.502 0.533 0.55" frameBottomColor="0.478 0.502 0.533 0.55" visible="false">
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard7Bg" position="0px 0px" size="270px 52px" imageColor="0.118 0.129 0.141 0.85"/>
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard7Mark" position="0px 0px" size="6px 52px" imageColor="0.549 0.776 0.247 1" visible="false"/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard7Num" position="12px -3px" size="40px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard7Name" position="50px -3px" size="212px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_HintText" id="rfPsCard7Benefit" position="12px -20px" size="252px 32px" textSize="13px"
-                                      textMaxNumLines="2" textVerticalAlignment="top" text=""/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard7Bg" position="0px 0px" size="276px 124px" imageColor="0.118 0.129 0.141 0.85"/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard7Mark" position="0px 0px" size="6px 124px" imageColor="0.549 0.776 0.247 1" visible="false"/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard7Num" position="12px -4px" size="44px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard7Name" position="56px -4px" size="208px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard7Benefit" position="12px -30px" size="252px 58px" textSize="16px"
+                                      textMaxNumLines="3" textVerticalAlignment="top" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard7Extra" position="12px -96px" size="252px 20px" textSize="14px" textMaxNumLines="1" textVerticalAlignment="top" text=""/>
                             </GuiElement>
-                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard8" position="844px -108px" size="270px 52px"
+                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard8" position="844px -170px" size="276px 124px"
                                         frameLeftColor="0.478 0.502 0.533 0.55" frameTopColor="0.478 0.502 0.533 0.55" frameRightColor="0.478 0.502 0.533 0.55" frameBottomColor="0.478 0.502 0.533 0.55" visible="false">
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard8Bg" position="0px 0px" size="270px 52px" imageColor="0.118 0.129 0.141 0.85"/>
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard8Mark" position="0px 0px" size="6px 52px" imageColor="0.549 0.776 0.247 1" visible="false"/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard8Num" position="12px -3px" size="40px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard8Name" position="50px -3px" size="212px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_HintText" id="rfPsCard8Benefit" position="12px -20px" size="252px 32px" textSize="13px"
-                                      textMaxNumLines="2" textVerticalAlignment="top" text=""/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard8Bg" position="0px 0px" size="276px 124px" imageColor="0.118 0.129 0.141 0.85"/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard8Mark" position="0px 0px" size="6px 124px" imageColor="0.549 0.776 0.247 1" visible="false"/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard8Num" position="12px -4px" size="44px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard8Name" position="56px -4px" size="208px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard8Benefit" position="12px -30px" size="252px 58px" textSize="16px"
+                                      textMaxNumLines="3" textVerticalAlignment="top" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard8Extra" position="12px -96px" size="252px 20px" textSize="14px" textMaxNumLines="1" textVerticalAlignment="top" text=""/>
                             </GuiElement>
-                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard9" position="10px -168px" size="270px 52px"
+                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard9" position="10px -314px" size="276px 124px"
                                         frameLeftColor="0.478 0.502 0.533 0.55" frameTopColor="0.478 0.502 0.533 0.55" frameRightColor="0.478 0.502 0.533 0.55" frameBottomColor="0.478 0.502 0.533 0.55" visible="false">
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard9Bg" position="0px 0px" size="270px 52px" imageColor="0.118 0.129 0.141 0.85"/>
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard9Mark" position="0px 0px" size="6px 52px" imageColor="0.549 0.776 0.247 1" visible="false"/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard9Num" position="12px -3px" size="40px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard9Name" position="50px -3px" size="212px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_HintText" id="rfPsCard9Benefit" position="12px -20px" size="252px 32px" textSize="13px"
-                                      textMaxNumLines="2" textVerticalAlignment="top" text=""/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard9Bg" position="0px 0px" size="276px 124px" imageColor="0.118 0.129 0.141 0.85"/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard9Mark" position="0px 0px" size="6px 124px" imageColor="0.549 0.776 0.247 1" visible="false"/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard9Num" position="12px -4px" size="44px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard9Name" position="56px -4px" size="208px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard9Benefit" position="12px -30px" size="252px 58px" textSize="16px"
+                                      textMaxNumLines="3" textVerticalAlignment="top" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard9Extra" position="12px -96px" size="252px 20px" textSize="14px" textMaxNumLines="1" textVerticalAlignment="top" text=""/>
                             </GuiElement>
-                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard10" position="288px -168px" size="270px 52px"
+                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard10" position="288px -314px" size="276px 124px"
                                         frameLeftColor="0.478 0.502 0.533 0.55" frameTopColor="0.478 0.502 0.533 0.55" frameRightColor="0.478 0.502 0.533 0.55" frameBottomColor="0.478 0.502 0.533 0.55" visible="false">
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard10Bg" position="0px 0px" size="270px 52px" imageColor="0.118 0.129 0.141 0.85"/>
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard10Mark" position="0px 0px" size="6px 52px" imageColor="0.549 0.776 0.247 1" visible="false"/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard10Num" position="12px -3px" size="40px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard10Name" position="50px -3px" size="212px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_HintText" id="rfPsCard10Benefit" position="12px -20px" size="252px 32px" textSize="13px"
-                                      textMaxNumLines="2" textVerticalAlignment="top" text=""/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard10Bg" position="0px 0px" size="276px 124px" imageColor="0.118 0.129 0.141 0.85"/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard10Mark" position="0px 0px" size="6px 124px" imageColor="0.549 0.776 0.247 1" visible="false"/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard10Num" position="12px -4px" size="44px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard10Name" position="56px -4px" size="208px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard10Benefit" position="12px -30px" size="252px 58px" textSize="16px"
+                                      textMaxNumLines="3" textVerticalAlignment="top" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard10Extra" position="12px -96px" size="252px 20px" textSize="14px" textMaxNumLines="1" textVerticalAlignment="top" text=""/>
                             </GuiElement>
-                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard11" position="566px -168px" size="270px 52px"
+                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard11" position="566px -314px" size="276px 124px"
                                         frameLeftColor="0.478 0.502 0.533 0.55" frameTopColor="0.478 0.502 0.533 0.55" frameRightColor="0.478 0.502 0.533 0.55" frameBottomColor="0.478 0.502 0.533 0.55" visible="false">
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard11Bg" position="0px 0px" size="270px 52px" imageColor="0.118 0.129 0.141 0.85"/>
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard11Mark" position="0px 0px" size="6px 52px" imageColor="0.549 0.776 0.247 1" visible="false"/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard11Num" position="12px -3px" size="40px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard11Name" position="50px -3px" size="212px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_HintText" id="rfPsCard11Benefit" position="12px -20px" size="252px 32px" textSize="13px"
-                                      textMaxNumLines="2" textVerticalAlignment="top" text=""/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard11Bg" position="0px 0px" size="276px 124px" imageColor="0.118 0.129 0.141 0.85"/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard11Mark" position="0px 0px" size="6px 124px" imageColor="0.549 0.776 0.247 1" visible="false"/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard11Num" position="12px -4px" size="44px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard11Name" position="56px -4px" size="208px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard11Benefit" position="12px -30px" size="252px 58px" textSize="16px"
+                                      textMaxNumLines="3" textVerticalAlignment="top" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard11Extra" position="12px -96px" size="252px 20px" textSize="14px" textMaxNumLines="1" textVerticalAlignment="top" text=""/>
                             </GuiElement>
-                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard12" position="844px -168px" size="270px 52px"
+                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard12" position="844px -314px" size="276px 124px"
                                         frameLeftColor="0.478 0.502 0.533 0.55" frameTopColor="0.478 0.502 0.533 0.55" frameRightColor="0.478 0.502 0.533 0.55" frameBottomColor="0.478 0.502 0.533 0.55" visible="false">
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard12Bg" position="0px 0px" size="270px 52px" imageColor="0.118 0.129 0.141 0.85"/>
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard12Mark" position="0px 0px" size="6px 52px" imageColor="0.549 0.776 0.247 1" visible="false"/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard12Num" position="12px -3px" size="40px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard12Name" position="50px -3px" size="212px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_HintText" id="rfPsCard12Benefit" position="12px -20px" size="252px 32px" textSize="13px"
-                                      textMaxNumLines="2" textVerticalAlignment="top" text=""/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard12Bg" position="0px 0px" size="276px 124px" imageColor="0.118 0.129 0.141 0.85"/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard12Mark" position="0px 0px" size="6px 124px" imageColor="0.549 0.776 0.247 1" visible="false"/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard12Num" position="12px -4px" size="44px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard12Name" position="56px -4px" size="208px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard12Benefit" position="12px -30px" size="252px 58px" textSize="16px"
+                                      textMaxNumLines="3" textVerticalAlignment="top" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard12Extra" position="12px -96px" size="252px 20px" textSize="14px" textMaxNumLines="1" textVerticalAlignment="top" text=""/>
                             </GuiElement>
-                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard13" position="10px -228px" size="270px 52px"
+                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard13" position="10px -458px" size="276px 124px"
                                         frameLeftColor="0.478 0.502 0.533 0.55" frameTopColor="0.478 0.502 0.533 0.55" frameRightColor="0.478 0.502 0.533 0.55" frameBottomColor="0.478 0.502 0.533 0.55" visible="false">
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard13Bg" position="0px 0px" size="270px 52px" imageColor="0.118 0.129 0.141 0.85"/>
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard13Mark" position="0px 0px" size="6px 52px" imageColor="0.549 0.776 0.247 1" visible="false"/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard13Num" position="12px -3px" size="40px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard13Name" position="50px -3px" size="212px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_HintText" id="rfPsCard13Benefit" position="12px -20px" size="252px 32px" textSize="13px"
-                                      textMaxNumLines="2" textVerticalAlignment="top" text=""/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard13Bg" position="0px 0px" size="276px 124px" imageColor="0.118 0.129 0.141 0.85"/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard13Mark" position="0px 0px" size="6px 124px" imageColor="0.549 0.776 0.247 1" visible="false"/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard13Num" position="12px -4px" size="44px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard13Name" position="56px -4px" size="208px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard13Benefit" position="12px -30px" size="252px 58px" textSize="16px"
+                                      textMaxNumLines="3" textVerticalAlignment="top" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard13Extra" position="12px -96px" size="252px 20px" textSize="14px" textMaxNumLines="1" textVerticalAlignment="top" text=""/>
                             </GuiElement>
-                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard14" position="288px -228px" size="270px 52px"
+                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard14" position="288px -458px" size="276px 124px"
                                         frameLeftColor="0.478 0.502 0.533 0.55" frameTopColor="0.478 0.502 0.533 0.55" frameRightColor="0.478 0.502 0.533 0.55" frameBottomColor="0.478 0.502 0.533 0.55" visible="false">
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard14Bg" position="0px 0px" size="270px 52px" imageColor="0.118 0.129 0.141 0.85"/>
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard14Mark" position="0px 0px" size="6px 52px" imageColor="0.549 0.776 0.247 1" visible="false"/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard14Num" position="12px -3px" size="40px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard14Name" position="50px -3px" size="212px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_HintText" id="rfPsCard14Benefit" position="12px -20px" size="252px 32px" textSize="13px"
-                                      textMaxNumLines="2" textVerticalAlignment="top" text=""/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard14Bg" position="0px 0px" size="276px 124px" imageColor="0.118 0.129 0.141 0.85"/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard14Mark" position="0px 0px" size="6px 124px" imageColor="0.549 0.776 0.247 1" visible="false"/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard14Num" position="12px -4px" size="44px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard14Name" position="56px -4px" size="208px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard14Benefit" position="12px -30px" size="252px 58px" textSize="16px"
+                                      textMaxNumLines="3" textVerticalAlignment="top" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard14Extra" position="12px -96px" size="252px 20px" textSize="14px" textMaxNumLines="1" textVerticalAlignment="top" text=""/>
                             </GuiElement>
-                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard15" position="566px -228px" size="270px 52px"
+                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard15" position="566px -458px" size="276px 124px"
                                         frameLeftColor="0.478 0.502 0.533 0.55" frameTopColor="0.478 0.502 0.533 0.55" frameRightColor="0.478 0.502 0.533 0.55" frameBottomColor="0.478 0.502 0.533 0.55" visible="false">
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard15Bg" position="0px 0px" size="270px 52px" imageColor="0.118 0.129 0.141 0.85"/>
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard15Mark" position="0px 0px" size="6px 52px" imageColor="0.549 0.776 0.247 1" visible="false"/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard15Num" position="12px -3px" size="40px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard15Name" position="50px -3px" size="212px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_HintText" id="rfPsCard15Benefit" position="12px -20px" size="252px 32px" textSize="13px"
-                                      textMaxNumLines="2" textVerticalAlignment="top" text=""/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard15Bg" position="0px 0px" size="276px 124px" imageColor="0.118 0.129 0.141 0.85"/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard15Mark" position="0px 0px" size="6px 124px" imageColor="0.549 0.776 0.247 1" visible="false"/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard15Num" position="12px -4px" size="44px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard15Name" position="56px -4px" size="208px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard15Benefit" position="12px -30px" size="252px 58px" textSize="16px"
+                                      textMaxNumLines="3" textVerticalAlignment="top" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard15Extra" position="12px -96px" size="252px 20px" textSize="14px" textMaxNumLines="1" textVerticalAlignment="top" text=""/>
                             </GuiElement>
-                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard16" position="844px -228px" size="270px 52px"
+                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard16" position="844px -458px" size="276px 124px"
                                         frameLeftColor="0.478 0.502 0.533 0.55" frameTopColor="0.478 0.502 0.533 0.55" frameRightColor="0.478 0.502 0.533 0.55" frameBottomColor="0.478 0.502 0.533 0.55" visible="false">
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard16Bg" position="0px 0px" size="270px 52px" imageColor="0.118 0.129 0.141 0.85"/>
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard16Mark" position="0px 0px" size="6px 52px" imageColor="0.549 0.776 0.247 1" visible="false"/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard16Num" position="12px -3px" size="40px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard16Name" position="50px -3px" size="212px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_HintText" id="rfPsCard16Benefit" position="12px -20px" size="252px 32px" textSize="13px"
-                                      textMaxNumLines="2" textVerticalAlignment="top" text=""/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard16Bg" position="0px 0px" size="276px 124px" imageColor="0.118 0.129 0.141 0.85"/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard16Mark" position="0px 0px" size="6px 124px" imageColor="0.549 0.776 0.247 1" visible="false"/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard16Num" position="12px -4px" size="44px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard16Name" position="56px -4px" size="208px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard16Benefit" position="12px -30px" size="252px 58px" textSize="16px"
+                                      textMaxNumLines="3" textVerticalAlignment="top" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard16Extra" position="12px -96px" size="252px 20px" textSize="14px" textMaxNumLines="1" textVerticalAlignment="top" text=""/>
                             </GuiElement>
-                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard17" position="10px -288px" size="270px 52px"
+                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard17" position="10px -602px" size="276px 124px"
                                         frameLeftColor="0.478 0.502 0.533 0.55" frameTopColor="0.478 0.502 0.533 0.55" frameRightColor="0.478 0.502 0.533 0.55" frameBottomColor="0.478 0.502 0.533 0.55" visible="false">
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard17Bg" position="0px 0px" size="270px 52px" imageColor="0.118 0.129 0.141 0.85"/>
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard17Mark" position="0px 0px" size="6px 52px" imageColor="0.549 0.776 0.247 1" visible="false"/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard17Num" position="12px -3px" size="40px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard17Name" position="50px -3px" size="212px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_HintText" id="rfPsCard17Benefit" position="12px -20px" size="252px 32px" textSize="13px"
-                                      textMaxNumLines="2" textVerticalAlignment="top" text=""/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard17Bg" position="0px 0px" size="276px 124px" imageColor="0.118 0.129 0.141 0.85"/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard17Mark" position="0px 0px" size="6px 124px" imageColor="0.549 0.776 0.247 1" visible="false"/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard17Num" position="12px -4px" size="44px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard17Name" position="56px -4px" size="208px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard17Benefit" position="12px -30px" size="252px 58px" textSize="16px"
+                                      textMaxNumLines="3" textVerticalAlignment="top" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard17Extra" position="12px -96px" size="252px 20px" textSize="14px" textMaxNumLines="1" textVerticalAlignment="top" text=""/>
                             </GuiElement>
-                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard18" position="288px -288px" size="270px 52px"
+                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard18" position="288px -602px" size="276px 124px"
                                         frameLeftColor="0.478 0.502 0.533 0.55" frameTopColor="0.478 0.502 0.533 0.55" frameRightColor="0.478 0.502 0.533 0.55" frameBottomColor="0.478 0.502 0.533 0.55" visible="false">
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard18Bg" position="0px 0px" size="270px 52px" imageColor="0.118 0.129 0.141 0.85"/>
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard18Mark" position="0px 0px" size="6px 52px" imageColor="0.549 0.776 0.247 1" visible="false"/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard18Num" position="12px -3px" size="40px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard18Name" position="50px -3px" size="212px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_HintText" id="rfPsCard18Benefit" position="12px -20px" size="252px 32px" textSize="13px"
-                                      textMaxNumLines="2" textVerticalAlignment="top" text=""/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard18Bg" position="0px 0px" size="276px 124px" imageColor="0.118 0.129 0.141 0.85"/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard18Mark" position="0px 0px" size="6px 124px" imageColor="0.549 0.776 0.247 1" visible="false"/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard18Num" position="12px -4px" size="44px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard18Name" position="56px -4px" size="208px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard18Benefit" position="12px -30px" size="252px 58px" textSize="16px"
+                                      textMaxNumLines="3" textVerticalAlignment="top" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard18Extra" position="12px -96px" size="252px 20px" textSize="14px" textMaxNumLines="1" textVerticalAlignment="top" text=""/>
                             </GuiElement>
-                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard19" position="566px -288px" size="270px 52px"
+                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard19" position="566px -602px" size="276px 124px"
                                         frameLeftColor="0.478 0.502 0.533 0.55" frameTopColor="0.478 0.502 0.533 0.55" frameRightColor="0.478 0.502 0.533 0.55" frameBottomColor="0.478 0.502 0.533 0.55" visible="false">
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard19Bg" position="0px 0px" size="270px 52px" imageColor="0.118 0.129 0.141 0.85"/>
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard19Mark" position="0px 0px" size="6px 52px" imageColor="0.549 0.776 0.247 1" visible="false"/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard19Num" position="12px -3px" size="40px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard19Name" position="50px -3px" size="212px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_HintText" id="rfPsCard19Benefit" position="12px -20px" size="252px 32px" textSize="13px"
-                                      textMaxNumLines="2" textVerticalAlignment="top" text=""/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard19Bg" position="0px 0px" size="276px 124px" imageColor="0.118 0.129 0.141 0.85"/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard19Mark" position="0px 0px" size="6px 124px" imageColor="0.549 0.776 0.247 1" visible="false"/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard19Num" position="12px -4px" size="44px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard19Name" position="56px -4px" size="208px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard19Benefit" position="12px -30px" size="252px 58px" textSize="16px"
+                                      textMaxNumLines="3" textVerticalAlignment="top" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard19Extra" position="12px -96px" size="252px 20px" textSize="14px" textMaxNumLines="1" textVerticalAlignment="top" text=""/>
                             </GuiElement>
-                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard20" position="844px -288px" size="270px 52px"
+                            <GuiElement profile="RF_EscCardFrame" id="rfPsCard20" position="844px -602px" size="276px 124px"
                                         frameLeftColor="0.478 0.502 0.533 0.55" frameTopColor="0.478 0.502 0.533 0.55" frameRightColor="0.478 0.502 0.533 0.55" frameBottomColor="0.478 0.502 0.533 0.55" visible="false">
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard20Bg" position="0px 0px" size="270px 52px" imageColor="0.118 0.129 0.141 0.85"/>
-                                <Bitmap profile="RF_EscCardRule" id="rfPsCard20Mark" position="0px 0px" size="6px 52px" imageColor="0.549 0.776 0.247 1" visible="false"/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard20Num" position="12px -3px" size="40px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_SectionTitle" id="rfPsCard20Name" position="50px -3px" size="212px 16px" textSize="14px" textMaxNumLines="1" text=""/>
-                                <Text profile="RF_HintText" id="rfPsCard20Benefit" position="12px -20px" size="252px 32px" textSize="13px"
-                                      textMaxNumLines="2" textVerticalAlignment="top" text=""/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard20Bg" position="0px 0px" size="276px 124px" imageColor="0.118 0.129 0.141 0.85"/>
+                                <Bitmap profile="RF_EscCardRule" id="rfPsCard20Mark" position="0px 0px" size="6px 124px" imageColor="0.549 0.776 0.247 1" visible="false"/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard20Num" position="12px -4px" size="44px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_SectionTitle" id="rfPsCard20Name" position="56px -4px" size="208px 22px" textSize="18px" textMaxNumLines="1" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard20Benefit" position="12px -30px" size="252px 58px" textSize="16px"
+                                      textMaxNumLines="3" textVerticalAlignment="top" text=""/>
+                                <Text profile="RF_HintText" id="rfPsCard20Extra" position="12px -96px" size="252px 20px" textSize="14px" textMaxNumLines="1" textVerticalAlignment="top" text=""/>
                             </GuiElement>
-                            <Text profile="RF_HintText" id="rfPsRecurring" position="10px -344px" size="1120px 22px"
+                            <Text profile="RF_HintText" id="rfPsRecurring" position="10px -726px" size="1120px 20px"
                                   textSize="15px" textMaxNumLines="1" visible="false" text=""/>
-                            <Text profile="RF_HintText" id="rfPsNote" position="10px -368px" size="1120px 24px"
-                                  textSize="13px" textMaxNumLines="1" visible="false" text=""/>
                         </GuiElement>
                     </GuiElement>
 
@@ -1161,23 +1273,23 @@
 
                     <!-- MDM TOP: commodities CROP / PRICE / CHANGE (GuiElement SmoothList parent; quiet reload). -->
                     <GuiElement profile="RF_MdTableRegionShell" id="mdTableRegion" position="0px 0px"
-                                absoluteSizeOffset="0px 388px" visible="false">
-                        <Text profile="RF_ColHeader" id="mdColCrop" text="" position="54px -8px" size="380px 24px"/>
-                        <Text profile="RF_ColHeader" id="mdColPrice" text="" position="460px -8px" size="280px 24px"/>
-                        <Text profile="RF_ColHeader" id="mdColChange" text="" position="760px -8px" size="280px 24px"/>
+                                absoluteSizeOffset="0px 456px" visible="false">
+                        <Text profile="RF_ColHeader" id="mdColCrop" textSize="15px" text="" position="54px -8px" size="380px 24px"/>
+                        <Text profile="RF_ColHeader" id="mdColPrice" textSize="15px" text="" position="460px -8px" size="280px 24px"/>
+                        <Text profile="RF_ColHeader" id="mdColChange" textSize="15px" text="" position="760px -8px" size="280px 24px"/>
 
                         <GuiElement profile="fs25_subCategoryListContainer" position="0px -32px"
                                     absoluteSizeOffset="0px 40px">
                             <SmoothList id="mdCommodityList" profile="RF_SmoothList"
                                         startClipperElementName="mdListStart"
                                         endClipperElementName="mdListEnd">
-                                <ListItem profile="RF_ListRowTall" onClick="onClickMdCommodityRow">
+                                <ListItem profile="RF_ListRowTall" height="40px" onClick="onClickMdCommodityRow">
                                     <Bitmap profile="RF_RowBg" name="alternating"/>
                                     <!-- Crop icon: Lua populate sets filename + visible per row (hide if no overlay; no purple). -->
                                     <Bitmap profile="RF_MdCropIcon" name="cropIcon" visible="false"/>
-                                    <Text profile="RF_CellLeft"   name="mdCropRowName"   position="38px 0px" size="400px 44px"/>
-                                    <Text profile="RF_CellLeft"   name="mdCropRowPrice"  position="460px 0px" size="280px 44px"/>
-                                    <Text profile="RF_CellLeft"   name="mdCropRowChange" position="760px 0px" size="280px 44px"/>
+                                    <Text profile="RF_CellLeft"   name="mdCropRowName" textSize="16px"   position="38px 0px" size="400px 44px"/>
+                                    <Text profile="RF_CellLeft"   name="mdCropRowPrice" textSize="16px"  position="460px 0px" size="280px 44px"/>
+                                    <Text profile="RF_CellLeft"   name="mdCropRowChange" textSize="16px" position="760px 0px" size="280px 44px"/>
                                 </ListItem>
                             </SmoothList>
                             <Bitmap profile="fs25_secondaryMenuStartClipper" name="mdListStart"/>
@@ -1199,14 +1311,14 @@
                                      onClick="onClickMdMoverSelector"/>
                     <GuiElement id="mdDetailStrip" position="0px 0px" size="1px 1px" visible="false"/>
 
-                    <!-- MDM BOTTOM: page-swapped band (Prices graph+detail | Events | Contracts). -->
+                    <!-- MDM BOTTOM: page-swapped band (Prices graph+detail | Events + Event Settings cards | Contracts). -->
                     <GuiElement profile="RF_TreatmentStrip" id="mdPageBand" visible="false">
                         <Bitmap profile="RF_TreatmentBoxBg"/>
 
                         <!-- Page A — Prices -->
                         <GuiElement profile="RF_EscCardFrameWide" id="mdPricesBand" visible="true" position="10px -10px" size="1130px 344px">
                             <Text profile="RF_SectionTitle" id="mdGraphTitle" position="10px -6px" size="700px 22px" text=""/>
-                            <GuiElement profile="RF_MdGraphArea" id="mdGraphArea" position="30px -28px"/>
+                            <GuiElement profile="RF_MdGraphArea" id="mdGraphArea" position="30px -56px" size="720px 248px"/>
             <Text profile="RF_EmptyHint" id="mdGraphEmptyHint" position="30px -86px" size="720px 40px"
                   visible="false" text=""/>
             <Text profile="RF_TreatSelected" id="mdDetailCommodity" position="770px -32px" size="350px 22px"
@@ -1215,73 +1327,127 @@
             <Text profile="RF_TreatTargetLine" id="mdDetailPressure" position="770px -92px" size="350px 20px" text=""/>
             <Text profile="RF_HintText" id="mdDetailEmpty" position="770px -64px" size="350px 44px"
                   textMaxNumLines="2" visible="false" text=""/>
-            <Button profile="buttonActivate" id="mdOpenMarketBtn" position="770px -280px" size="350px 36px"
-                    onClick="onClickMdOpenMarket"/>
+            <!-- BUILD 12:05 (George CLOSED DESIGN 09:45): the Open full Market plate is gone; this page is the Market. -->
                         </GuiElement>
 
                         <!-- Page B — Events (fixed Text rows; no SmoothList thrash). -->
-                        <GuiElement profile="RF_EscCardFrameWide" id="mdEventsBand" visible="false" position="10px -10px" size="1130px 344px">
-                            <Text profile="RF_SectionTitle" id="mdEventsTitle" position="10px -6px" size="700px 22px" text=""/>
-                            <Text profile="RF_ColHeader" id="mdEvColName" position="10px -36px" size="420px 20px" text=""/>
-                            <Text profile="RF_ColHeader" id="mdEvColIntensity" position="450px -36px" size="220px 20px" text=""/>
-                            <Text profile="RF_ColHeader" id="mdEvColTime" position="690px -36px" size="420px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdEvRow1Name" position="10px -64px" size="420px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdEvRow1Intensity" position="450px -64px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdEvRow1Time" position="690px -64px" size="420px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdEvRow2Name" position="10px -92px" size="420px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdEvRow2Intensity" position="450px -92px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdEvRow2Time" position="690px -92px" size="420px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdEvRow3Name" position="10px -120px" size="420px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdEvRow3Intensity" position="450px -120px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdEvRow3Time" position="690px -120px" size="420px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdEvRow4Name" position="10px -148px" size="420px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdEvRow4Intensity" position="450px -148px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdEvRow4Time" position="690px -148px" size="420px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdEvRow5Name" position="10px -176px" size="420px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdEvRow5Intensity" position="450px -176px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdEvRow5Time" position="690px -176px" size="420px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdEvRow6Name" position="10px -204px" size="420px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdEvRow6Intensity" position="450px -204px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdEvRow6Time" position="690px -204px" size="420px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdEvMore" position="10px -240px" size="1100px 20px" text=""/>
-                            <Text profile="RF_HintText" id="mdEventsEmpty" position="10px -64px" size="1100px 44px"
-                                  textMaxNumLines="2" visible="false" text=""/>
-            <Button profile="buttonActivate" id="mdOpenMarketBtnEvents" position="770px -280px" size="350px 36px"
-                    onClick="onClickMdOpenMarket"/>
+                        <!-- BUILD 16:42 (George CLOSED DESIGN 16:25): Events is two cards like Contracts. Left = live
+                             events, eight fixed Text rows; right = the Event Settings summary and the plate that opens the
+                             existing 800x800 MDMEventSettingsDialog (host/admin/master gate, never inlined). The EVENT /
+                             STATE list stays in the dialog. No SmoothList in this band. -->
+                        <GuiElement profile="RF_WcPage" id="mdEventsBand" visible="false" position="10px -10px" size="1130px 344px">
+                            <GuiElement profile="RF_EscCardFrame" id="mdEventsOpenCard" position="0px 0px" size="550px 344px">
+                                <Text profile="RF_SectionTitle" id="mdEventsTitle" position="10px -6px" size="530px 22px" text=""/>
+                                <Text profile="RF_ColHeader" id="mdEvColName" position="10px -36px" size="210px 20px" text=""/>
+                                <Text profile="RF_ColHeader" id="mdEvColIntensity" position="230px -36px" size="110px 20px" text=""/>
+                                <Text profile="RF_ColHeader" id="mdEvColTime" position="350px -36px" size="200px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdEvRow1Name" position="10px -62px" size="210px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdEvRow1Intensity" position="230px -62px" size="110px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdEvRow1Time" position="350px -62px" size="200px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdEvRow2Name" position="10px -86px" size="210px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdEvRow2Intensity" position="230px -86px" size="110px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdEvRow2Time" position="350px -86px" size="200px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdEvRow3Name" position="10px -110px" size="210px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdEvRow3Intensity" position="230px -110px" size="110px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdEvRow3Time" position="350px -110px" size="200px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdEvRow4Name" position="10px -134px" size="210px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdEvRow4Intensity" position="230px -134px" size="110px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdEvRow4Time" position="350px -134px" size="200px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdEvRow5Name" position="10px -158px" size="210px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdEvRow5Intensity" position="230px -158px" size="110px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdEvRow5Time" position="350px -158px" size="200px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdEvRow6Name" position="10px -182px" size="210px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdEvRow6Intensity" position="230px -182px" size="110px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdEvRow6Time" position="350px -182px" size="200px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdEvRow7Name" position="10px -206px" size="210px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdEvRow7Intensity" position="230px -206px" size="110px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdEvRow7Time" position="350px -206px" size="200px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdEvRow8Name" position="10px -230px" size="210px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdEvRow8Intensity" position="230px -230px" size="110px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdEvRow8Time" position="350px -230px" size="200px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdEvMore" position="10px -276px" size="530px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdEventsEmpty" position="10px -62px" size="530px 44px"
+                                      textMaxNumLines="2" visible="false" text=""/>
+                            </GuiElement>
+                            <GuiElement profile="RF_EscCardFrame" id="mdEsSummaryCard" position="580px 0px" size="550px 344px">
+                                <Text profile="RF_SectionTitle" id="mdEventSettingsTitle" position="10px -6px" size="530px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="mdEsGlobal" position="10px -34px" size="530px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="mdEsFreq" position="10px -58px" size="530px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="mdEsEnabled" position="10px -82px" size="530px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="mdEsActive" position="10px -106px" size="530px 22px" text=""/>
+                                <Text profile="RF_HintText" id="mdEsHint" position="10px -130px" size="530px 66px" textMaxNumLines="3" text=""/>
+                                <Button profile="RF_CsPivotBtn" id="mdEventSettingsBtn" position="10px -296px" size="250px 32px" handleFocus="false" text="" onClick="onClickMdEventSettings"/>
+                            </GuiElement>
                         </GuiElement>
 
                         <!-- Page C — Contracts (read-only fixed rows). -->
-                        <GuiElement profile="RF_EscCardFrameWide" id="mdContractsBand" visible="false" position="10px -10px" size="1130px 344px">
-                            <Text profile="RF_SectionTitle" id="mdContractsTitle" position="10px -6px" size="900px 22px" text=""/>
-                            <Text profile="RF_ColHeader" id="mdCtColCrop" position="10px -36px" size="280px 20px" text=""/>
-                            <Text profile="RF_ColHeader" id="mdCtColQty" position="300px -36px" size="220px 20px" text=""/>
-                            <Text profile="RF_ColHeader" id="mdCtColPrice" position="540px -36px" size="280px 20px" text=""/>
-                            <Text profile="RF_ColHeader" id="mdCtColStatus" position="840px -36px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdCtRow1Crop" position="10px -64px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdCtRow1Qty" position="300px -64px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdCtRow1Price" position="540px -64px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdCtRow1Status" position="840px -64px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdCtRow2Crop" position="10px -92px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdCtRow2Qty" position="300px -92px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdCtRow2Price" position="540px -92px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdCtRow2Status" position="840px -92px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdCtRow3Crop" position="10px -120px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdCtRow3Qty" position="300px -120px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdCtRow3Price" position="540px -120px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdCtRow3Status" position="840px -120px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdCtRow4Crop" position="10px -148px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdCtRow4Qty" position="300px -148px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdCtRow4Price" position="540px -148px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdCtRow4Status" position="840px -148px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdCtRow5Crop" position="10px -176px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdCtRow5Qty" position="300px -176px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdCtRow5Price" position="540px -176px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdCtRow5Status" position="840px -176px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="mdCtMore" position="10px -212px" size="1100px 20px" text=""/>
-                            <Text profile="RF_HintText" id="mdContractsEmpty" position="10px -64px" size="1100px 44px"
-                                  textMaxNumLines="2" visible="false" text=""/>
-            <Button profile="buttonActivate" id="mdOpenMarketBtnContracts" position="770px -280px" size="350px 36px"
-                    onClick="onClickMdOpenMarket"/>
+                        <!-- BUILD 10:47 (George CLOSED DESIGN 10:37): the Contracts band is two cards in the same
+                             1130x344 slot. Left = open deals (fixed Text rows, read-only). Right = compact New Contract
+                             (quantity + window + confirm) for the crop picked in mdCommodityList above. BUILD 11:42:
+                             the compact card is the only create path (Full form dropped). No SmoothList in this band.
+                             Chips, Confirm and Event settings are RF_CsPivotBtn pivot plates with handleFocus=false:
+                             mouse click only. Space (MENU_ACTIVATE) only paints a glyph on a Button, and Return
+                             (MENU_ACCEPT) fires the FOCUSED element through FocusManager, so an unfocusable plate can
+                             never confirm a contract from the keyboard. Open full Market keeps buttonActivate. -->
+                        <GuiElement profile="RF_WcPage" id="mdContractsBand" visible="false" position="10px -10px" size="1130px 344px">
+                            <GuiElement profile="RF_EscCardFrame" id="mdContractsOpenCard" position="0px 0px" size="550px 344px">
+                                <Text profile="RF_SectionTitle" id="mdContractsTitle" textSize="17px" position="10px -6px" size="530px 22px" text=""/>
+                                <Text profile="RF_ColHeader" id="mdCtColCrop" textSize="15px" position="10px -36px" size="150px 20px" text=""/>
+                                <Text profile="RF_ColHeader" id="mdCtColQty" textSize="15px" position="165px -36px" size="100px 20px" text=""/>
+                                <Text profile="RF_ColHeader" id="mdCtColPrice" textSize="15px" position="270px -36px" size="150px 20px" text=""/>
+                                <Text profile="RF_ColHeader" id="mdCtColStatus" textSize="15px" position="425px -36px" size="115px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdCtRow1Crop" textSize="13px" position="10px -62px" size="150px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdCtRow1Qty" textSize="13px" position="165px -62px" size="100px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdCtRow1Price" textSize="13px" position="270px -62px" size="150px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdCtRow1Status" textSize="13px" position="425px -62px" size="115px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdCtRow2Crop" textSize="13px" position="10px -86px" size="150px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdCtRow2Qty" textSize="13px" position="165px -86px" size="100px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdCtRow2Price" textSize="13px" position="270px -86px" size="150px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdCtRow2Status" textSize="13px" position="425px -86px" size="115px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdCtRow3Crop" textSize="13px" position="10px -110px" size="150px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdCtRow3Qty" textSize="13px" position="165px -110px" size="100px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdCtRow3Price" textSize="13px" position="270px -110px" size="150px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdCtRow3Status" textSize="13px" position="425px -110px" size="115px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdCtRow4Crop" textSize="13px" position="10px -134px" size="150px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdCtRow4Qty" textSize="13px" position="165px -134px" size="100px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdCtRow4Price" textSize="13px" position="270px -134px" size="150px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdCtRow4Status" textSize="13px" position="425px -134px" size="115px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdCtRow5Crop" textSize="13px" position="10px -158px" size="150px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdCtRow5Qty" textSize="13px" position="165px -158px" size="100px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdCtRow5Price" textSize="13px" position="270px -158px" size="150px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdCtRow5Status" textSize="13px" position="425px -158px" size="115px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdCtMore" textSize="13px" position="10px -186px" size="530px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdContractsEmpty" textSize="13px" position="10px -62px" size="530px 44px"
+                                      textMaxNumLines="2" visible="false" text=""/>
+                            </GuiElement>
+                            <GuiElement profile="RF_EscCardFrame" id="mdNewContractCard" position="580px 0px" size="550px 344px">
+                                <Text profile="RF_SectionTitle" id="mdNewContractTitle" position="10px -6px" size="530px 22px" text=""/>
+                                <Text profile="RF_TreatSelected" id="mdNcCrop" position="10px -34px" size="530px 22px" text=""/>
+                                <Text profile="RF_HintText" id="mdNcPrice" position="10px -58px" size="530px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdNcQtyLabel" position="10px -82px" size="200px 20px" text=""/>
+                                <Button profile="RF_CsPivotBtn" id="mdNcQty500" position="10px -104px" size="80px 32px" handleFocus="false" text="" onClick="onClickMdNcQty"/>
+                                <Button profile="RF_CsPivotBtn" id="mdNcQty1000" position="96px -104px" size="80px 32px" handleFocus="false" text="" onClick="onClickMdNcQty"/>
+                                <Button profile="RF_CsPivotBtn" id="mdNcQty5000" position="182px -104px" size="80px 32px" handleFocus="false" text="" onClick="onClickMdNcQty"/>
+                                <Button profile="RF_CsPivotBtn" id="mdNcQty10000" position="268px -104px" size="80px 32px" handleFocus="false" text="" onClick="onClickMdNcQty"/>
+                                <Button profile="RF_CsPivotBtn" id="mdNcQty25000" position="354px -104px" size="80px 32px" handleFocus="false" text="" onClick="onClickMdNcQty"/>
+                                <Button profile="RF_CsPivotBtn" id="mdNcQty50000" position="440px -104px" size="80px 32px" handleFocus="false" text="" onClick="onClickMdNcQty"/>
+                                <Text profile="RF_HintText" id="mdNcDaysLabel" position="10px -142px" size="530px 20px" text=""/>
+                                <Button profile="RF_CsPivotBtn" id="mdNcDays30" position="10px -164px" size="80px 32px" handleFocus="false" text="" onClick="onClickMdNcDays"/>
+                                <Button profile="RF_CsPivotBtn" id="mdNcDays60" position="96px -164px" size="80px 32px" handleFocus="false" text="" onClick="onClickMdNcDays"/>
+                                <Button profile="RF_CsPivotBtn" id="mdNcDays90" position="182px -164px" size="80px 32px" handleFocus="false" text="" onClick="onClickMdNcDays"/>
+                                <Button profile="RF_CsPivotBtn" id="mdNcDays120" position="268px -164px" size="80px 32px" handleFocus="false" text="" onClick="onClickMdNcDays"/>
+                                <Text profile="RF_HintText" id="mdNcDaysUnit" position="360px -170px" size="180px 20px" text=""/>
+                                <!-- Total in six adjacent Text nodes: only the money and the days number are yellow
+                                     (RF_ProductCell), a Giants TextElement is one colour (BUILD 11:42). -->
+                                <Text profile="RF_HintText" id="mdNcSumLabel" position="10px -206px" size="60px 20px" text=""/>
+                                <Text profile="RF_ProductCell" id="mdNcSumMoney" position="72px -206px" size="200px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdNcSumFor" position="280px -206px" size="250px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdNcSumWinLabel" position="10px -228px" size="110px 20px" text=""/>
+                                <Text profile="RF_ProductCell" id="mdNcSumDays" position="124px -228px" size="50px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdNcSumUnit" position="180px -228px" size="350px 20px" text=""/>
+                                <Text profile="RF_HintText" id="mdNcHint" position="10px -252px" size="530px 40px" textMaxNumLines="2" text=""/>
+                                <Button profile="RF_CsPivotBtn" id="mdNewContractBtn" position="10px -296px" size="250px 32px" handleFocus="false" text="" onClick="onClickMdNewContract"/>
+                            </GuiElement>
                         </GuiElement>
                     </GuiElement>
 

--- a/xml/gui/rfEscProfiles.xml
+++ b/xml/gui/rfEscProfiles.xml
@@ -387,10 +387,15 @@
          inputAction MENU_ACTIVATE (base game guiProfiles.xml:2084-2087). The engine paints
          that action's SPACE key chip on every button carrying it, which is what shoved each
          label out of its own 120px box and into the next button ("< BACK" + the neighbouring
-         chip is what read as "BACKSPACE" on screen). hideKeyboardGlyph did NOT suppress it
-         here - it appears exactly once in the whole base-game profile set, on a disabled
-         gamepad-only selector - and isTriggerableByGlobalAction is not an engine property at
-         all (zero occurrences base game), so both were inert.
+         chip is what read as "BACKSPACE" on screen).
+         BUILD 00:06 correction (George CLOSED DESIGN 23:12, decompiled ButtonElement.lua /
+         ScreenElement.lua): the sentence that used to sit here calling hideKeyboardGlyph and
+         isTriggerableByGlobalAction inert was wrong. Both are real ButtonElement fields:
+         hideKeyboardGlyph (ButtonElement.lua default :22, profile :131) skips the SPACE chip at
+         draw :461-463, and isTriggerableByGlobalAction (default :27, profile :137) gates the
+         global-action trigger at ScreenElement.lua:76 (vanilla: CareerScreen.lua:58). That is
+         exactly what RF_CsPivotBtn relies on for every overlay chip, and the 2026-08-22 pager
+         failure came from a door whose profile copy predated those two values.
          fs25_wideButton (guiProfiles.xml:2671) is buttonActivate's OWN base minus the
          inputAction, so this profile is the same chrome with no key chip to draw. The mouse
          click still works: it runs through onClick, which never needed the input action.
@@ -537,9 +542,10 @@
         <position value="0px 0px"/>
     </Profile>
 
-    <!-- MDM TOP commodities vs BOTTOM band (368)+L(~20): MDM-only; do not change shared Soil table shell. -->
+    <!-- MDM TOP commodities vs BOTTOM band: reserve = RF_TreatmentStrip 432 + 24 air, so the last crop row
+         clears the PRICE TREND card title (BUILD 09:32). MDM-only; do not change shared Soil table shell. -->
     <Profile name="RF_MdTableRegionShell" extends="emptyPanel" with="anchorStretchingYStretchingX pivotTopLeft">
-        <absoluteSizeOffset value="0px 388px"/>
+        <absoluteSizeOffset value="0px 456px"/>
         <position value="0px 0px"/>
     </Profile>
 
@@ -683,6 +689,44 @@
     <!-- F8: taller rows for +2 textSize -->
     <Profile name="RF_ListRowTall" extends="emptyPanel" with="anchorTopStretchingX pivotTopLeft">
         <height value="48px"/>
+    </Profile>
+
+    <!-- BUILD 00:06 (George CLOSED DESIGN 23:12): NPC Favor scrollable tables inside rfFwTableBlock.
+         Box = fixed top-left panel the SmoothList stretches into (mdCommodityList uses the engine
+         fs25_subCategoryListContainer; these boxes are placed by px inside the 1140x780 bay instead).
+         Roster rows 60px (two text lines), favor rows 32px (one line). Cells are RF_CellLeft at the
+         framework 16px, not bold, vertically centred. -->
+    <Profile name="RF_FwListBox" extends="emptyPanel" with="anchorTopLeft pivotTopLeft">
+        <size value="1120px 420px"/>
+        <position value="0px 0px"/>
+        <clipChildren value="false"/>
+        <handleFocus value="false"/>
+    </Profile>
+    <Profile name="RF_FwRosterList" extends="RF_SmoothList">
+        <size value="1100px 420px"/>
+        <handleFocus value="false"/>
+    </Profile>
+    <Profile name="RF_FwFavorList" extends="RF_SmoothList">
+        <size value="1100px 224px"/>
+        <handleFocus value="false"/>
+    </Profile>
+    <Profile name="RF_FwRosterItem" extends="RF_ListRow">
+        <height value="60px"/>
+    </Profile>
+    <Profile name="RF_FwFavorItem" extends="RF_ListRow">
+        <height value="32px"/>
+    </Profile>
+    <Profile name="RF_FwListCell" extends="RF_CellLeft">
+        <textSize value="16px"/>
+        <textBold value="false"/>
+        <textMaxNumLines value="2"/>
+        <textVerticalAlignment value="middle"/>
+    </Profile>
+    <Profile name="RF_FwFavCell" extends="RF_CellLeft">
+        <textSize value="15px"/>
+        <textBold value="false"/>
+        <textMaxNumLines value="1"/>
+        <textVerticalAlignment value="middle"/>
     </Profile>
 
     <!-- F12: STATUS body cells centered. -->


### PR DESCRIPTION
## Summary
- Put hire, fire, wage options, Reset, and the crew board on the Realistic Farming Worker Costs page so the old Worker Manager footer is not needed (Wizard asked to move that work here, then drop the leftover link).
- Settings overlay chips sit next to their titles. Reset lines up with the page. Shared door copy carries the new XML so any host can serve this page.
- Intended Lua removals (Wizard): Worker Manager footer; Open full Market (`onClickMdOpenMarket`) after that desk moved onto the Market glance; old `seedSubnav` helper (Worker Costs is one page now).

## Files
- `src/gui/WcRfPdaGuest.lua`
- `src/gui/RfPdaMenuPage.lua`, `src/gui/RfEscModules.lua`
- `xml/gui/RfPdaMenuPage.xml`, `xml/gui/rfEscProfiles.xml`
- `modDesc.xml` (version bump only)

## Test plan
- [ ] Full client start.
- [ ] Esc Realistic Farming > Worker Costs: wage chips do not cover their labels; Reset lines up; Hire / Fire sit on the matching crew and recruit rows.
- [ ] No Open Worker Manager footer action. Hire / fire / wage / Reset work on this page.
- [ ] SPACE does not confirm a chip. Overlay chips idle dark+lime, latched lime+dark.
- [ ] Alone and in the full suite: Worker Costs door still opens; leave and return; no hang.
