### PR TITLE
feat(payroll): RSF-F223 payroll calendar, farm ownership and the loan bill read

### DIFF
--- a/src/WorkerManager.lua
+++ b/src/WorkerManager.lua
@@ -182,6 +182,14 @@ function WorkerManager:onMissionLoaded()
         -- After initialize() so nothing clobbers the loaded values.
         if g_currentMission and g_currentMission:getIsServer() then
             self.workerSystem:loadMonthlyState(g_currentMission.missionInfo)
+            -- F223: apply the native MP-to-SP farm conversion map ONCE, after the
+            -- snapshot is loaded and native farm loading has completed (mergedFarms is
+            -- populated during FarmManager load, before loadMission00Finished). A repeat
+            -- load/map cannot double-pool: remap retargets ids without re-adding money.
+            local fm = g_farmManager
+            if fm ~= nil and type(fm.mergedFarms) == "table" and next(fm.mergedFarms) ~= nil then
+                self.workerSystem:remapMergedFarms(fm.mergedFarms)
+            end
         end
     end
 
@@ -405,15 +413,13 @@ function WorkerManager:getServerSnapshot()
     local baseRate   = (settings and settings.getWageRate and settings:getWageRate()) or 0
     local isHourly   = (settings and settings.costMode == Settings.COST_MODE_HOURLY) and true or false
 
-    -- Aggregate "this month" accrued wages from the worker system.
+    -- Aggregate "this month" accrued wages from the worker system. F223: monthlyCosts
+    -- is now nested per farm, and frozen unpaid bills also carry owed base wages, so the
+    -- display aggregate is assembled by the owner helper (unbilled base + unpaid frozen
+    -- base portions). Keeps the existing "base accrual" meaning; no penalised final here.
     local monthAccrued = 0
-    if workerSys and workerSys.monthlyCosts then
-        -- Entries are { name, amount, farmId } tables, not raw numbers.
-        for _, entry in pairs(workerSys.monthlyCosts) do
-            if entry and entry.amount then
-                monthAccrued = monthAccrued + entry.amount
-            end
-        end
+    if workerSys and workerSys._baseAccrualAggregate then
+        monthAccrued = workerSys:_baseAccrualAggregate()
     end
 
     local snapshot = {
@@ -565,6 +571,33 @@ function WorkerManager:getWorkersForFarm(farmId)
     if type(farmId) ~= "number" or farmId <= 0 then return {} end
     local snap = self:getRosterSnapshot()
     return (snap and snap.workers) or {}
+end
+
+-- =========================================================
+-- F223 / C3: payroll obligations read contract (for the emergency-loan forecast)
+-- =========================================================
+-- IncomeMod's emergency loan calls this COLON method on mission.workerCostsManager to
+-- learn a farm's dated payroll cash bills for its one-period cash forecast. Server-only
+-- and PURE: it never issues, pays, flushes open work or migrates (the owner keeps its
+-- money and formulas; C3 only reads). Delegates to the WorkerSystem collector, which
+-- returns a copied version-1 snapshot that never aliases live payroll state. `horizon`
+-- carries the shared date contract { asOf, horizonEnd, daysPerPeriod, dayInPeriod }.
+---@param farmId number
+---@param horizon table
+---@return table  version-1 payroll obligations snapshot
+function WorkerManager:getPayrollObligations(farmId, horizon)
+    if self.workerSystem and self.workerSystem.getPayrollObligations then
+        return self.workerSystem:getPayrollObligations(farmId, horizon)
+    end
+    return {
+        version         = (WorkerSystem and WorkerSystem.PAYROLL_CONTRACT_VERSION) or 1,
+        status          = "UNAVAILABLE",
+        farmId          = farmId,
+        enabled         = false,
+        settlementMode  = "IMMEDIATE",
+        coverageReasons = { "NO_WORKER_SYSTEM" },
+        events          = {},
+    }
 end
 
 -- =========================================================

--- a/src/WorkerSystem.lua
+++ b/src/WorkerSystem.lua
@@ -72,15 +72,53 @@ function WorkerSystem.new(settings, roster)
     self._originalAddMoney = nil   -- stored so we can restore on delete
     self._hookedAddMoney = false
 
-    -- Monthly salary tracking
-    -- monthlyCosts[workerId] = { name = displayName, amount = accumulated $ for this month }
+    -- Monthly salary tracking (F223: per-farm, never pooled into the first farm).
+    -- Nested accrual so two farms sharing one worker key stay distinct:
+    --   monthlyCosts[farmId][workerKey] = { name = displayName, amount = accrued $ }
+    -- workerKey is always a canonical string (tostring of the roster uuid / vehicle id).
     self.monthlyCosts   = {}
+    -- F223 frozen bills: a month-end issue freezes ONE bill, moving the accrued rows
+    -- OUT of live accrual so later wages are distinct. Parts are per-farm and carry
+    -- their own payment disposition so a partial/failed farm never loses or repeats.
+    --   salaryBills[billId] = {
+    --     id, issuedYear, issuedPeriod, penaltyApplied,
+    --     parts = { [farmId] = { name, base, final, remaining, status } } }
+    -- status is UNPAID / PAID / INDETERMINATE (WorkerSystem.PART_*).
+    self.salaryBills    = {}
+    self.nextBillId     = 1        -- monotonic, persisted; never reused after payoff
     self.lastDay        = -1       -- last in-game day we checked
-    self.lastMonthPaid  = -1       -- last in-game month that triggered the salary dialog
-    self.declinedLastMonth = false -- true if player skipped last month's payment
-    self.pendingSalary  = nil      -- { entries, total, month } stored while dialog is open
+    -- F223: issuance is keyed by the native ordinal (year*PERIODS_IN_YEAR+period-1),
+    -- kept SEPARATE from any bill's payment state, so a new year's same-named period
+    -- can issue again and a repeated same-period check cannot issue twice.
+    self.lastIssuedOrdinal = -1
+    self.lastMonthPaid  = -1       -- LEGACY schema-1 field; retained only for load seeding
+    self.declinedLastMonth = false -- true if player declined last bill (next bill +20%)
+    self.pendingSalary  = nil      -- { billId, entries, total, month } while dialog is open
+    -- F223: legacy schema-1 rows with no valid recorded farm. Never defaulted to a
+    -- farm, never charged to a borrower; retained as inspectable evidence only.
+    self.legacyUnattributed = {}
 
     return self
+end
+
+-- F223 bill-part payment disposition.
+WorkerSystem.PART_UNPAID        = "UNPAID"
+WorkerSystem.PART_PAID          = "PAID"
+WorkerSystem.PART_INDETERMINATE = "INDETERMINATE"
+
+-- Periods (months) per native year. Engine constant (Environment.PERIODS_IN_YEAR=12);
+-- read the live constant when present so a future engine change cannot silently drift.
+function WorkerSystem._periodsInYear()
+    if Environment ~= nil and Environment.PERIODS_IN_YEAR ~= nil then
+        return Environment.PERIODS_IN_YEAR
+    end
+    return 12
+end
+
+-- The issuance ordinal for a (year, period) pair: a strictly increasing integer so a
+-- later period always compares greater and a new year's period 1 follows last year's.
+function WorkerSystem._issuanceOrdinal(year, period)
+    return year * WorkerSystem._periodsInYear() + period - 1
 end
 
 function WorkerSystem:initialize()
@@ -203,12 +241,20 @@ function WorkerSystem:installGameHook()
             local isHelperWage = (aiType ~= nil and moneyType == aiType)
                               or (wageType ~= nil and moneyType == wageType)
 
-            -- Last-resort heuristic ONLY when this build exposes NEITHER wage
-            -- MoneyType. Previously it fired whenever MoneyType.AI was nil even if
-            -- WORKER_WAGES existed, so it could eat any unrelated negative <=500
-            -- (e.g. a small purchase) during a job. Now gated on both being absent,
-            -- and it warns visibly since suppression here is an informed guess.
-            if not isHelperWage and aiType == nil and wageType == nil then
+            -- F223/R1: forward every explicit KNOWN non-wage MoneyType (e.g. OTHER)
+            -- through the captured chain BEFORE any missing-enum/magnitude heuristic.
+            -- Only an unknown/nil type may be guessed at. Previously, when this build
+            -- exposed neither AI nor WORKER_WAGES, the heuristic could swallow a typed
+            -- OTHER charge <=500 during a job — eating IncomeMod's loan/tax/repayment
+            -- deductions. A known OTHER is never a helper wage. (Owner-predicate fix,
+            -- not a second money writer; AI/WORKER_WAGES keep their real suppression.)
+            local otherType    = MoneyType and MoneyType.OTHER
+            local knownNonWage = (otherType ~= nil and moneyType == otherType)
+
+            -- Last-resort heuristic ONLY when this build exposes NEITHER wage MoneyType
+            -- AND the charge is not a known non-wage type. Gated on both enums being
+            -- absent; warns visibly since suppression here is an informed guess.
+            if not isHelperWage and not knownNonWage and aiType == nil and wageType == nil then
                 local hasActiveJobs = false
                 local aiSystem = g_currentMission and g_currentMission.aiSystem
                 if aiSystem and aiSystem.getActiveJobs then
@@ -620,14 +666,20 @@ function WorkerSystem:chargeWage(workerId, workerName, amount, workType, silent,
     -- moving any money. The accrual is persisted (saveMonthlyState) so a mid-month
     -- reload cannot drop what is owed.
     if self.settings.monthlySalaryEnabled then
-        local entry = self.monthlyCosts[workerId]
+        -- F223: accrue under farmId -> canonical worker key. The same worker working
+        -- for two farms keeps two distinct entries (no first-farm pooling), so each
+        -- farm is billed exactly its own work.
+        local farmBook = self.monthlyCosts[farmId]
+        if farmBook == nil then
+            farmBook = {}
+            self.monthlyCosts[farmId] = farmBook
+        end
+        local key = tostring(workerId)
+        local entry = farmBook[key]
         if entry then
             entry.amount = entry.amount + amount
-            if entry.farmId == nil then
-                entry.farmId = farmId
-            end
         else
-            self.monthlyCosts[workerId] = { name = workerName, amount = amount, farmId = farmId }
+            farmBook[key] = { name = workerName, amount = amount }
         end
         self:log("%s %s wage accrued for monthly salary: %d (farm %d)", workerName, workType, amount, farmId)
         return true
@@ -789,9 +841,9 @@ function WorkerSystem:update(dt)
     -- Monthly salary: check if the last day of the month has just been reached
     if self.settings.monthlySalaryEnabled then
         self:checkMonthEnd()
-    elseif next(self.monthlyCosts) ~= nil then
-        -- Monthly mode was switched off with wages still accrued: settle once now
-        -- so the accrual is never orphaned (money still moves exactly once).
+    elseif self:_hasAccrual() or next(self.salaryBills) ~= nil then
+        -- Monthly mode was switched off with wages still accrued or a bill still owed:
+        -- settle once now so nothing is orphaned (money still moves exactly once).
         self:settlePendingMonthlyAccrual()
     end
 end
@@ -896,89 +948,233 @@ end
 -- Monthly salary system
 -- ─────────────────────────────────────────────────────────
 
+-- F223 accrual helpers (the nested monthlyCosts[farmId][workerKey] book).
+
+--- Total unbilled accrual per farm: { [farmId] = sum of that farm's worker amounts }.
+function WorkerSystem:_accrualByFarm()
+    local byFarm = {}
+    for farmId, farmBook in pairs(self.monthlyCosts or {}) do
+        local sum = 0
+        for _, entry in pairs(farmBook) do
+            if entry and entry.amount and entry.amount > 0 then
+                sum = sum + entry.amount
+            end
+        end
+        if sum > 0 then
+            byFarm[farmId] = sum
+        end
+    end
+    return byFarm
+end
+
+--- Grand total of all unbilled accrual across every farm.
+function WorkerSystem:_accrualTotal()
+    local total = 0
+    for _, sum in pairs(self:_accrualByFarm()) do
+        total = total + sum
+    end
+    return total
+end
+
+--- Any unbilled accrual present? (replaces the old `next(monthlyCosts)` test, which
+--- is now truthy for an empty per-farm book.)
+function WorkerSystem:_hasAccrual()
+    for _, farmBook in pairs(self.monthlyCosts or {}) do
+        for _, entry in pairs(farmBook) do
+            if entry and entry.amount and entry.amount > 0 then
+                return true
+            end
+        end
+    end
+    return false
+end
+
+--- F223 Direction 13: the legacy `monthAccrued` display aggregate — unbilled base
+--- accrual plus the unpaid BASE (pre-penalty) portions of frozen bills. It keeps its
+--- old "base accrual this month" meaning; the penalised final bill is not summed here.
+function WorkerSystem:_baseAccrualAggregate()
+    local total = self:_accrualTotal()
+    for _, bill in pairs(self.salaryBills or {}) do
+        for _, part in ipairs(bill.parts or {}) do
+            if part.status == WorkerSystem.PART_UNPAID and (part.remaining or 0) > 0 then
+                total = total + (part.base or 0)
+            end
+        end
+    end
+    return total
+end
+
+--- Re-accrue one worker row under a farm (used by Decline to return unpaid base rows).
+function WorkerSystem:_accrueRow(farmId, key, name, amount)
+    if farmId == nil or amount == nil or amount <= 0 then return end
+    local farmBook = self.monthlyCosts[farmId]
+    if farmBook == nil then
+        farmBook = {}
+        self.monthlyCosts[farmId] = farmBook
+    end
+    key = tostring(key)
+    local entry = farmBook[key]
+    if entry then
+        entry.amount = entry.amount + amount
+    else
+        farmBook[key] = { name = name or "Worker", amount = amount }
+    end
+end
+
 --- Called every update tick when monthlySalaryEnabled is true.
--- Detects the transition to the last day of the month (day 28 in FS25
--- which uses 28-day months) and triggers the salary dialog once.
+-- F223: issue the monthly bill on the real last day of the period for ANY configured
+-- month length, keyed by the native ordinal so it fires once per (year, period). The
+-- old `currentDay >= currentPeriod*28` test never reached the last day of a month with
+-- daysPerPeriod other than 28 (e.g. a 3-day month), silently skipping the bill.
 function WorkerSystem:checkMonthEnd()
     if not g_currentMission or not g_currentMission.environment then
         return
     end
     local env = g_currentMission.environment
 
-    -- FS25 months have 28 in-game days (1..28).
-    -- We trigger on day 28 so that the player pays before the month rolls over.
-    local currentDay   = env.currentDay         -- 1-based day within the current year
-    local currentMonth = env.currentPeriod      -- 1-based period/month index
+    local dayInPeriod   = env.currentDayInPeriod
+    local daysPerPeriod = env.daysPerPeriod
+    local year          = env.currentYear
+    local period        = env.currentPeriod
 
-    if currentDay == nil or currentMonth == nil then
+    -- Validate the native ordinal calendar; an inconsistent/unready sample is not a
+    -- due date. (currentDayInPeriod = (currentDay-1) % daysPerPeriod + 1 in the engine.)
+    if type(dayInPeriod) ~= "number" or type(daysPerPeriod) ~= "number"
+        or type(year) ~= "number" or type(period) ~= "number"
+        or daysPerPeriod < 1 or dayInPeriod < 1 or dayInPeriod > daysPerPeriod
+        or period < 1 or year < 0 then
         return
     end
 
-    -- Only fire once per month
-    if currentMonth == self.lastMonthPaid then
+    -- The last day of the period (on a one-day month, that one day is the last day).
+    if dayInPeriod ~= daysPerPeriod then
         return
     end
 
-    -- Days per month in FS25 = 28 (7 periods × 28 days each → 196-day year).
-    -- env.currentDay is the absolute day of the year (1-196).
-    -- Last day of each period = period * 28.
-    local lastDayOfThisMonth = currentMonth * 28
-
-    -- Fire once when the last day of the period is reached.
-    -- The outer `currentMonth == self.lastMonthPaid` check above already
-    -- prevents re-entry for the same month, so no inner guard is needed.
-    if currentDay >= lastDayOfThisMonth then
-        self.lastMonthPaid = currentMonth
-        self:triggerMonthlySalaryDialog(currentMonth)
+    -- Issue once per (year, period): a strictly increasing ordinal lets a new year's
+    -- same-named period issue again and blocks a repeated same-period check.
+    local ordinal = WorkerSystem._issuanceOrdinal(year, period)
+    if self.lastIssuedOrdinal ~= nil and self.lastIssuedOrdinal >= 0
+        and ordinal <= self.lastIssuedOrdinal then
+        return
     end
+    self.lastIssuedOrdinal = ordinal
+    self.lastMonthPaid = period  -- legacy mirror only; payment state lives on the bill
+    self:triggerMonthlySalaryDialog(period)
 end
 
 --- Build the salary summary and show the dialog (or pay silently if no GUI).
 ---@param month number  in-game month index
 function WorkerSystem:triggerMonthlySalaryDialog(month)
-    -- Flush any pending interval payments silently — the monthly dialog is
-    -- the single summary notification. Per-payment alerts here would be noise.
+    -- Flush any pending interval payments silently — the bill is the single summary.
     self:processWorkerPayments(true)
 
-    -- Build the entry list
-    local entries = {}
-    local total   = 0
-
-    for workerId, entry in pairs(self.monthlyCosts) do
-        if entry.amount > 0 then
-            -- Apply 20 % late-payment penalty if player declined last month
-            local finalAmount = entry.amount
-            if self.declinedLastMonth then
-                finalAmount = math.floor(entry.amount * 1.20)
-                self:log("Late-pay penalty applied to %s: $%d -> $%d", entry.name, entry.amount, finalAmount)
-            end
-            table.insert(entries, { name = entry.name, amount = finalAmount, farmId = entry.farmId })
-            total = total + finalAmount
-        end
-    end
-
-    -- Sort alphabetically for consistent display
-    table.sort(entries, function(a, b) return a.name < b.name end)
-
-    if total == 0 then
+    -- F223: freeze ONE immutable bill from the current accrual. This moves the accrued
+    -- rows OUT of live accrual so wages earned after issuance stay distinct, and bakes
+    -- the decline penalty (per-entry floor(base*1.20)) into the frozen final amounts.
+    local bill = self:_freezeMonthlyBill(month)
+    if bill == nil then
         self:log("Monthly salary: no costs accumulated — skipping dialog")
-        self.monthlyCosts = {}
         self.declinedLastMonth = false
         return
     end
 
+    local entries, total = self:_billEntries(bill)
     self:log("Monthly salary dialog triggered: month=%d, workers=%d, total=$%d", month, #entries, total)
 
-    -- Store for the callbacks
-    self.pendingSalary = { entries = entries, total = total, month = month }
+    -- Store the billId so Pay/Decline bind to THIS exact frozen bill, never to
+    -- whichever object happens to be pending when the button is clicked.
+    self.pendingSalary = { billId = bill.id, entries = entries, total = total, month = month }
 
-    -- Try to show the in-game GUI dialog; fall back to silent payment on dedicated/headless
     if g_gui and g_client then
         self:showSalaryDialog(entries, total, month)
     else
-        -- Dedicated server or no GUI — pay automatically
+        -- Dedicated server or no GUI — pay automatically.
         self:executeMonthlySalaryPayment()
     end
+end
+
+--- F223: freeze the current accrual into one immutable bill with per-farm parts. Each
+--- part keeps its exact base rows (pre-penalty) plus the per-entry priced final, so
+--- Pay/Decline bind to frozen amounts and later wages never change a displayed quote.
+---@param month number  in-game period index
+---@return table|nil bill  the frozen bill, or nil when nothing was accrued
+function WorkerSystem:_freezeMonthlyBill(month)
+    local env = g_currentMission and g_currentMission.environment
+    local year = (env and env.currentYear) or 0
+    local penalty = self.declinedLastMonth == true
+
+    -- parts is a LIST (not farm-keyed): an MP->SP conversion can retarget two old
+    -- parts onto one surviving farm, and each must still be consumed exactly once.
+    local parts = {}
+    for farmId, farmBook in pairs(self.monthlyCosts or {}) do
+        local baseRows, base, final = {}, 0, 0
+        for key, entry in pairs(farmBook) do
+            if entry and entry.amount and entry.amount > 0 then
+                baseRows[#baseRows + 1] = { key = key, name = entry.name or "Worker", amount = entry.amount }
+                base = base + entry.amount
+                -- Per-entry penalty floor (never compounded into principal).
+                final = final + (penalty and math.floor(entry.amount * 1.20) or entry.amount)
+            end
+        end
+        if base > 0 then
+            parts[#parts + 1] = {
+                farmId    = farmId,
+                baseRows  = baseRows,
+                base      = base,
+                final     = final,
+                remaining = final,
+                status    = WorkerSystem.PART_UNPAID,
+            }
+        end
+    end
+
+    if #parts == 0 then
+        return nil
+    end
+
+    local bill = {
+        id             = self.nextBillId,
+        issuedYear     = year,
+        issuedPeriod   = month,
+        penaltyApplied = penalty,
+        parts          = parts,
+    }
+    self.nextBillId = self.nextBillId + 1
+    self.salaryBills[bill.id] = bill
+
+    -- Move rows OUT of live accrual; wages after issuance accrue into a fresh book.
+    -- The penalty (if any) is now baked into this bill, so clear the carry-over flag.
+    self.monthlyCosts = {}
+    self.declinedLastMonth = false
+    return bill
+end
+
+--- Per-worker display rows for a frozen bill (alphabetical), plus the bill total.
+function WorkerSystem:_billEntries(bill)
+    local entries, total = {}, 0
+    local penalty = bill.penaltyApplied == true
+    for _, part in ipairs(bill.parts or {}) do
+        for _, row in ipairs(part.baseRows or {}) do
+            local amount = penalty and math.floor(row.amount * 1.20) or row.amount
+            entries[#entries + 1] = { name = row.name, amount = amount, farmId = part.farmId }
+            total = total + amount
+        end
+    end
+    table.sort(entries, function(a, b) return (a.name or "") < (b.name or "") end)
+    return entries, total
+end
+
+--- A bill is fully resolved when no part still owes money (UNPAID/INDETERMINATE with a
+--- positive remaining). Only then is it safe to drop from the book.
+function WorkerSystem:_billFullyResolved(bill)
+    for _, part in ipairs(bill.parts or {}) do
+        if (part.status == WorkerSystem.PART_UNPAID or part.status == WorkerSystem.PART_INDETERMINATE)
+            and (part.remaining or 0) > 0 then
+            return false
+        end
+    end
+    return true
 end
 
 --- Show the salary summary to the player using the registered WCSalaryDialog screen.
@@ -1018,91 +1214,110 @@ function WorkerSystem:showSalaryDialog(entries, total, month)
     end
 end
 
---- Deduct the monthly salary from the farm balance.
+--- Pay the salary bill the player just confirmed. Binds to the EXACT frozen bill id
+--- stored when the dialog opened, never to whatever accrual is current now.
 function WorkerSystem:executeMonthlySalaryPayment()
     if not self.pendingSalary then
         return
     end
-
-    local entries = self.pendingSalary.entries
-    local total   = self.pendingSalary.total
-    local month   = self.pendingSalary.month
+    local billId = self.pendingSalary.billId
+    local month  = self.pendingSalary.month
     self.pendingSalary = nil
+    self:paySalaryBill(billId, month)
+end
 
-    if total <= 0 then
-        self.monthlyCosts      = {}
-        self.declinedLastMonth = false
+--- Pay the UNPAID parts of one specific frozen bill. Each farm part retires exactly
+--- once on success; a native addMoney that throws leaves that part INDETERMINATE
+--- (retained, never auto-retried or treated as paid). A farm with no resolvable id
+--- this tick keeps its UNPAID part for a later attempt. The bill is dropped from the
+--- book only when no part still owes money (Direction 4 / native addMoney has no
+--- success boolean, so we validate farm/server before mutating and never fabricate).
+---@param billId number|nil
+---@param month number|nil  for the log line only
+function WorkerSystem:paySalaryBill(billId, month)
+    local bill = billId and self.salaryBills[billId]
+    if bill == nil then
         return
     end
 
-    -- Charge per owning farm (explicit farmId on each accrual). Dedicated-safe.
-    local byFarm = {}
-    for _, entry in ipairs(entries or {}) do
-        local fid = self:_resolveBillingFarmId(entry.farmId)
-        if fid ~= nil and entry.amount and entry.amount > 0 then
-            byFarm[fid] = (byFarm[fid] or 0) + entry.amount
-        end
-    end
-    if next(byFarm) == nil then
-        -- Legacy accrual without farmId: try local real farm only.
-        local fallback = self:_resolveBillingFarmId(nil)
-        if fallback == nil then
-            self:log("executeMonthlySalaryPayment: no valid farmId, skipping")
-            self.monthlyCosts      = {}
-            self.declinedLastMonth = false
-            return
-        end
-        byFarm[fallback] = total
-    end
-
-    local paidOk = true
-    for farmId, farmTotal in pairs(byFarm) do
-        self._isProcessingPayment = true
-        local ok, err = pcall(function()
-            g_currentMission:addMoney(-farmTotal, farmId, MoneyType.OTHER, false)
-        end)
-        self._isProcessingPayment = false
-        if not ok then
-            paidOk = false
-            self:log("executeMonthlySalaryPayment: addMoney error farm %d: %s", farmId, tostring(err))
+    local paidTotal, paidFarms = 0, 0
+    for _, part in ipairs(bill.parts) do
+        if part.status == WorkerSystem.PART_UNPAID and (part.remaining or 0) > 0 then
+            local fid = self:_resolveBillingFarmId(part.farmId)
+            if fid ~= nil then
+                self._isProcessingPayment = true
+                local ok, err = pcall(function()
+                    g_currentMission:addMoney(-part.remaining, fid, MoneyType.OTHER, false)
+                end)
+                self._isProcessingPayment = false
+                if ok then
+                    paidTotal = paidTotal + part.remaining
+                    paidFarms = paidFarms + 1
+                    part.remaining = 0
+                    part.status = WorkerSystem.PART_PAID
+                else
+                    -- Unknown native effect: retain evidence, do not retry or mark paid.
+                    part.status = WorkerSystem.PART_INDETERMINATE
+                    self:log("paySalaryBill: addMoney error farm %s: %s", tostring(fid), tostring(err))
+                end
+            end
         end
     end
 
-    if paidOk then
-        self:log("Monthly salary paid: month=%d, workers=%d, total=%d", month, #entries, total)
+    if self:_billFullyResolved(bill) then
+        self.salaryBills[billId] = nil
+    end
 
+    if paidTotal > 0 then
+        self:log("Monthly salary bill %s (month %s): paid %d across %d farm(s)",
+            tostring(billId), tostring(month), paidTotal, paidFarms)
         if self.settings.showNotifications then
-            local money = g_i18n and g_i18n:formatMoney(total, 0, true, true) or tostring(total)
-            local msg = string.format("Monthly salary paid: %s for %d worker(s)", money, #entries)
-            self:showNotification("Monthly Salary", msg)
+            local money = g_i18n and g_i18n:formatMoney(paidTotal, 0, true, true) or tostring(paidTotal)
+            self:showNotification("Monthly Salary",
+                string.format("Monthly salary paid: %s for %d farm(s)", money, paidFarms))
         end
     end
-
-    -- Reset for next month
-    self.monthlyCosts      = {}
-    self.declinedLastMonth = false
 end
 
---- Called when the player declines to pay the monthly salary.
+--- Called when the player declines to pay the monthly salary. F223: return only the
+--- UNPAID frozen BASE rows (pre-penalty) to live accrual, so the next bill re-prices
+--- them once with the existing floor(base*1.20) rule — the penalty is never compounded
+--- into principal or added as a new fee. Set the global decline flag for the next bill.
 function WorkerSystem:declineMonthlySalary()
     if not self.pendingSalary then
         return
     end
-
-    local total = self.pendingSalary.total
-    local month = self.pendingSalary.month
+    local billId = self.pendingSalary.billId
+    local total  = self.pendingSalary.total
+    local month  = self.pendingSalary.month
     self.pendingSalary = nil
 
-    self:log("Monthly salary DECLINED: month=%d, total=$%d — penalty will apply next month", month, total)
+    local bill = billId and self.salaryBills[billId]
+    if bill then
+        for _, part in ipairs(bill.parts) do
+            if part.status == WorkerSystem.PART_UNPAID then
+                for _, row in ipairs(part.baseRows or {}) do
+                    self:_accrueRow(part.farmId, row.key, row.name, row.amount)
+                end
+                -- This part's obligation is back in accrual; it no longer owes on the bill.
+                part.remaining = 0
+                part.status = WorkerSystem.PART_PAID  -- resolved-off-bill (moved to accrual)
+            end
+        end
+        -- Drop the bill once nothing on it still owes (PAID/returned parts only).
+        if self:_billFullyResolved(bill) then
+            self.salaryBills[billId] = nil
+        end
+    end
+
+    self.declinedLastMonth = true
+    self:log("Monthly salary DECLINED: month=%s, total=$%d — penalty applies next bill", tostring(month), total)
 
     if self.settings.showNotifications then
         local money = g_i18n and g_i18n:formatMoney(total, 0, true, true) or tostring(total)
         self:showNotification("Monthly Salary Declined",
             string.format("Warning: %s salary declined — workers will demand 20%% more next month!", money))
     end
-
-    -- Keep monthlyCosts so the unpaid amounts carry over and are penalised next month
-    self.declinedLastMonth = true
 end
 
 -- ─────────────────────────────────────────────────────────
@@ -1115,7 +1330,10 @@ end
 -- ─────────────────────────────────────────────────────────
 WorkerSystem.MONTHLY_SAVE_FILE      = "workerMonthlySalary.xml"
 WorkerSystem.MONTHLY_SAVE_ROOT      = "workerMonthlySalary"
-WorkerSystem.MONTHLY_SCHEMA_VERSION = "1"
+-- F223 schema 2: nested per-farm accrual, frozen bills with per-farm parts + base
+-- rows, the issuance ordinal and nextBillId, and retained legacy-unattributed rows.
+-- Schema 1 (flat worker rows) is migrated on load, never rewritten in place.
+WorkerSystem.MONTHLY_SCHEMA_VERSION = "2"
 
 function WorkerSystem:saveMonthlyState(missionInfo)
     local dir = missionInfo and missionInfo.savegameDirectory
@@ -1132,21 +1350,75 @@ function WorkerSystem:saveMonthlyState(missionInfo)
 
     local root = WorkerSystem.MONTHLY_SAVE_ROOT
     xmlFile:setString(root .. "#version", WorkerSystem.MONTHLY_SCHEMA_VERSION)
-    xmlFile:setInt(root .. "#lastMonthPaid", self.lastMonthPaid or -1)
+    xmlFile:setInt(root .. "#lastIssuedOrdinal", self.lastIssuedOrdinal or -1)
+    xmlFile:setInt(root .. "#nextBillId", self.nextBillId or 1)
+    xmlFile:setInt(root .. "#lastMonthPaid", self.lastMonthPaid or -1)  -- legacy mirror
     xmlFile:setBool(root .. "#declinedLastMonth", self.declinedLastMonth == true)
 
-    local i = 0
-    for workerId, entry in pairs(self.monthlyCosts or {}) do
-        if entry and entry.amount and entry.amount > 0 then
-            local key = string.format("%s.worker(%d)", root, i)
-            xmlFile:setString(key .. "#id", tostring(workerId))
-            xmlFile:setString(key .. "#name", entry.name)
-            xmlFile:setInt(key .. "#amount", math.floor(entry.amount))
-            if entry.farmId ~= nil then
-                xmlFile:setInt(key .. "#farmId", entry.farmId)
-            end
-            i = i + 1
+    -- Unbilled accrual, nested farm -> worker (explicit-empty is a valid save).
+    local fi = 0
+    for farmId, farmBook in pairs(self.monthlyCosts or {}) do
+        local hasRows = false
+        for _, e in pairs(farmBook) do
+            if e and e.amount and e.amount > 0 then hasRows = true; break end
         end
+        if hasRows and self:_isRealFarmId(farmId) then
+            local fkey = string.format("%s.accrual.farm(%d)", root, fi)
+            xmlFile:setInt(fkey .. "#id", farmId)
+            local wi = 0
+            for key, entry in pairs(farmBook) do
+                if entry and entry.amount and entry.amount > 0 then
+                    local wkey = string.format("%s.worker(%d)", fkey, wi)
+                    xmlFile:setString(wkey .. "#key", tostring(key))
+                    xmlFile:setString(wkey .. "#name", entry.name or "Worker")
+                    xmlFile:setInt(wkey .. "#amount", math.floor(entry.amount))
+                    wi = wi + 1
+                end
+            end
+            fi = fi + 1
+        end
+    end
+
+    -- Frozen bills with per-farm parts and their exact base rows.
+    local bi = 0
+    for _, bill in pairs(self.salaryBills or {}) do
+        local bkey = string.format("%s.bills.bill(%d)", root, bi)
+        xmlFile:setInt(bkey .. "#id", bill.id)
+        xmlFile:setInt(bkey .. "#issuedYear", bill.issuedYear or 0)
+        xmlFile:setInt(bkey .. "#issuedPeriod", bill.issuedPeriod or 0)
+        xmlFile:setBool(bkey .. "#penaltyApplied", bill.penaltyApplied == true)
+        local pi = 0
+        for _, part in ipairs(bill.parts or {}) do
+            local pkey = string.format("%s.part(%d)", bkey, pi)
+            xmlFile:setInt(pkey .. "#farmId", part.farmId or 0)
+            xmlFile:setInt(pkey .. "#base", math.floor(part.base or 0))
+            xmlFile:setInt(pkey .. "#final", math.floor(part.final or 0))
+            xmlFile:setInt(pkey .. "#remaining", math.floor(part.remaining or 0))
+            xmlFile:setString(pkey .. "#status", part.status or WorkerSystem.PART_UNPAID)
+            local ri = 0
+            for _, row in ipairs(part.baseRows or {}) do
+                local rkey = string.format("%s.row(%d)", pkey, ri)
+                xmlFile:setString(rkey .. "#key", tostring(row.key))
+                xmlFile:setString(rkey .. "#name", row.name or "Worker")
+                xmlFile:setInt(rkey .. "#amount", math.floor(row.amount or 0))
+                ri = ri + 1
+            end
+            pi = pi + 1
+        end
+        bi = bi + 1
+    end
+
+    -- Retained legacy-unattributed rows (evidence only; never charged or defaulted).
+    local li = 0
+    for _, row in ipairs(self.legacyUnattributed or {}) do
+        local lkey = string.format("%s.legacyUnattributed.row(%d)", root, li)
+        xmlFile:setString(lkey .. "#id", tostring(row.id))
+        xmlFile:setString(lkey .. "#name", row.name or "Worker")
+        xmlFile:setInt(lkey .. "#amount", math.floor(row.amount or 0))
+        if row.recordedFarmId ~= nil then
+            xmlFile:setInt(lkey .. "#recordedFarmId", row.recordedFarmId)
+        end
+        li = li + 1
     end
 
     xmlFile:save()
@@ -1167,25 +1439,129 @@ function WorkerSystem:loadMonthlyState(missionInfo)
     end
 
     local root = WorkerSystem.MONTHLY_SAVE_ROOT
-    self.lastMonthPaid     = xmlFile:getInt(root .. "#lastMonthPaid", self.lastMonthPaid or -1)
-    self.declinedLastMonth = xmlFile:getBool(root .. "#declinedLastMonth", false)
+    local version = xmlFile:getString(root .. "#version") or "1"
 
-    self.monthlyCosts = {}
-    xmlFile:iterate(root .. ".worker", function(_, key)
-        local name   = xmlFile:getString(key .. "#name")
-        local amount = xmlFile:getInt(key .. "#amount", 0)
-        local id     = xmlFile:getString(key .. "#id") or name
-        local farmId = xmlFile:getInt(key .. "#farmId", 0)
-        if name and amount > 0 then
-            local entry = { name = name, amount = amount }
-            if farmId and farmId > 0 then
-                entry.farmId = farmId
+    -- Read everything into temporary state, validate, then install once. Never
+    -- overwrite a live book on a repeated load (Direction 7).
+    local accrual, bills, legacy = {}, {}, {}
+    local declined           = xmlFile:getBool(root .. "#declinedLastMonth", false)
+    local legacyLastMonthPaid = xmlFile:getInt(root .. "#lastMonthPaid", -1)
+    local nextBillId         = 1
+    local lastIssuedOrdinal  = -1
+
+    if version == WorkerSystem.MONTHLY_SCHEMA_VERSION then
+        lastIssuedOrdinal = xmlFile:getInt(root .. "#lastIssuedOrdinal", -1)
+        nextBillId        = xmlFile:getInt(root .. "#nextBillId", 1)
+
+        xmlFile:iterate(root .. ".accrual.farm", function(_, fkey)
+            local farmId = xmlFile:getInt(fkey .. "#id", 0)
+            if self:_isRealFarmId(farmId) then
+                local book = accrual[farmId] or {}
+                xmlFile:iterate(fkey .. ".worker", function(_, wkey)
+                    local key    = xmlFile:getString(wkey .. "#key")
+                    local name   = xmlFile:getString(wkey .. "#name") or "Worker"
+                    local amount = xmlFile:getInt(wkey .. "#amount", 0)
+                    if key and amount > 0 then
+                        local existing = book[key]
+                        if existing then existing.amount = existing.amount + amount
+                        else book[key] = { name = name, amount = amount } end
+                    end
+                end)
+                if next(book) ~= nil then accrual[farmId] = book end
             end
-            self.monthlyCosts[id] = entry
+        end)
+
+        xmlFile:iterate(root .. ".bills.bill", function(_, bkey)
+            local id = xmlFile:getInt(bkey .. "#id", 0)
+            if id and id > 0 then
+                local bill = {
+                    id             = id,
+                    issuedYear     = xmlFile:getInt(bkey .. "#issuedYear", 0),
+                    issuedPeriod   = xmlFile:getInt(bkey .. "#issuedPeriod", 0),
+                    penaltyApplied = xmlFile:getBool(bkey .. "#penaltyApplied", false),
+                    parts          = {},
+                }
+                xmlFile:iterate(bkey .. ".part", function(_, pkey)
+                    local part = {
+                        farmId    = xmlFile:getInt(pkey .. "#farmId", 0),
+                        base      = xmlFile:getInt(pkey .. "#base", 0),
+                        final     = xmlFile:getInt(pkey .. "#final", 0),
+                        remaining = xmlFile:getInt(pkey .. "#remaining", 0),
+                        status    = xmlFile:getString(pkey .. "#status") or WorkerSystem.PART_UNPAID,
+                        baseRows  = {},
+                    }
+                    xmlFile:iterate(pkey .. ".row", function(_, rkey)
+                        local k = xmlFile:getString(rkey .. "#key")
+                        local n = xmlFile:getString(rkey .. "#name") or "Worker"
+                        local a = xmlFile:getInt(rkey .. "#amount", 0)
+                        if k then part.baseRows[#part.baseRows + 1] = { key = k, name = n, amount = a } end
+                    end)
+                    bill.parts[#bill.parts + 1] = part
+                end)
+                bills[id] = bill
+                if id >= nextBillId then nextBillId = id + 1 end
+            end
+        end)
+
+        xmlFile:iterate(root .. ".legacyUnattributed.row", function(_, lkey)
+            local amount = xmlFile:getInt(lkey .. "#amount", 0)
+            if amount > 0 then
+                local rf = xmlFile:getInt(lkey .. "#recordedFarmId", -1)
+                legacy[#legacy + 1] = {
+                    id             = xmlFile:getString(lkey .. "#id"),
+                    name           = xmlFile:getString(lkey .. "#name") or "Worker",
+                    amount         = amount,
+                    recordedFarmId = (rf ~= -1) and rf or nil,
+                }
+            end
+        end)
+    else
+        -- Schema 1 migration: flat worker rows {id, name, amount, farmId}. A valid
+        -- recorded farm becomes carried unbilled accrual; a missing/invalid target is
+        -- retained as legacy-unattributed evidence, never defaulted to a farm or
+        -- charged to a borrower (Direction 8). Old first-farm pooling is NOT undone:
+        -- a previously pooled amount keeps its whole recorded target.
+        xmlFile:iterate(root .. ".worker", function(_, wkey)
+            local id     = xmlFile:getString(wkey .. "#id")
+            local name   = xmlFile:getString(wkey .. "#name") or "Worker"
+            local amount = xmlFile:getInt(wkey .. "#amount", 0)
+            local farmId = xmlFile:getInt(wkey .. "#farmId", 0)
+            if amount > 0 then
+                if self:_isRealFarmId(farmId) then
+                    local book = accrual[farmId] or {}
+                    local key  = tostring(id or name)
+                    local existing = book[key]
+                    if existing then existing.amount = existing.amount + amount
+                    else book[key] = { name = name, amount = amount } end
+                    accrual[farmId] = book
+                else
+                    legacy[#legacy + 1] = { id = id or name, name = name, amount = amount,
+                        recordedFarmId = (farmId ~= 0) and farmId or nil }
+                end
+            end
+        end)
+
+        -- Direction 9: a legacy lastMonthPaid matching the currently loaded period
+        -- seeds this period's issuance ordinal so we do not re-issue it; a nonmatching
+        -- marker seeds nothing. New (schema 2) saves carry the exact ordinal, so this
+        -- ambiguity cannot recur.
+        local env = g_currentMission and g_currentMission.environment
+        if env and type(env.currentPeriod) == "number" and type(env.currentYear) == "number"
+            and legacyLastMonthPaid >= 1 and env.currentPeriod == legacyLastMonthPaid then
+            lastIssuedOrdinal = WorkerSystem._issuanceOrdinal(env.currentYear, legacyLastMonthPaid)
         end
-    end)
+    end
 
     xmlFile:delete()
+
+    -- Install once.
+    self.monthlyCosts       = accrual
+    self.salaryBills        = bills
+    self.legacyUnattributed = legacy
+    self.nextBillId         = math.max(1, nextBillId)
+    self.lastIssuedOrdinal  = lastIssuedOrdinal
+    self.declinedLastMonth  = declined
+    self.lastMonthPaid      = legacyLastMonthPaid
     return true
 end
 
@@ -1194,64 +1570,260 @@ end
 --- orphaned - the money still moves exactly once. Keeps the accrual on failure
 --- (e.g. no valid farm yet) so the next update tick retries.
 function WorkerSystem:settlePendingMonthlyAccrual()
-    if not self.monthlyCosts then
-        return
-    end
+    -- F223: settle per farm so a farm that cannot be charged this tick keeps its own
+    -- state and retries later (money still moves exactly once). Covers both unbilled
+    -- accrual and any still-owed frozen bill parts, so switching monthly mode off never
+    -- orphans money. Accrual farm ids are always real (stored at accrual time).
+    local paidTotal, paidFarms = 0, 0
 
-    local total = 0
-    for _, entry in pairs(self.monthlyCosts) do
-        if entry and entry.amount and entry.amount > 0 then
-            total = total + entry.amount
+    -- 1) Unbilled accrual, per farm.
+    for farmId, farmBook in pairs(self.monthlyCosts or {}) do
+        local sum = 0
+        for _, entry in pairs(farmBook) do
+            if entry and entry.amount and entry.amount > 0 then
+                sum = sum + entry.amount
+            end
         end
-    end
-
-    if total <= 0 then
-        self.monthlyCosts = {}
-        return
-    end
-
-    -- Charge per owning farm from accrual entries (dedicated-safe).
-    local byFarm = {}
-    for _, entry in pairs(self.monthlyCosts) do
-        if entry and entry.amount and entry.amount > 0 then
-            local fid = self:_resolveBillingFarmId(entry.farmId)
-            if fid ~= nil then
-                byFarm[fid] = (byFarm[fid] or 0) + entry.amount
+        if sum > 0 and self:_isRealFarmId(farmId) then
+            self._isProcessingPayment = true
+            local ok, err = pcall(function()
+                g_currentMission:addMoney(-sum, farmId, MoneyType.OTHER, false)
+            end)
+            self._isProcessingPayment = false
+            if ok then
+                self.monthlyCosts[farmId] = nil
+                paidTotal = paidTotal + sum
+                paidFarms = paidFarms + 1
+            else
+                self:log("settlePendingMonthlyAccrual: addMoney error farm %s: %s", tostring(farmId), tostring(err))
             end
         end
     end
-    if next(byFarm) == nil then
-        local fallback = self:_resolveBillingFarmId(nil)
-        if fallback == nil then
-            return  -- no valid farm this tick; keep the accrual and retry
+
+    -- 2) Still-owed frozen bill parts, per farm.
+    for billId, bill in pairs(self.salaryBills or {}) do
+        for _, part in ipairs(bill.parts) do
+            if part.status == WorkerSystem.PART_UNPAID and (part.remaining or 0) > 0
+                and self:_isRealFarmId(part.farmId) then
+                self._isProcessingPayment = true
+                local ok = pcall(function()
+                    g_currentMission:addMoney(-part.remaining, part.farmId, MoneyType.OTHER, false)
+                end)
+                self._isProcessingPayment = false
+                if ok then
+                    paidTotal = paidTotal + part.remaining
+                    part.remaining = 0
+                    part.status = WorkerSystem.PART_PAID
+                end
+            end
         end
-        byFarm[fallback] = total
-    end
-
-    local paidOk = true
-    for farmId, farmTotal in pairs(byFarm) do
-        self._isProcessingPayment = true
-        local ok, err = pcall(function()
-            g_currentMission:addMoney(-farmTotal, farmId, MoneyType.OTHER, false)
-        end)
-        self._isProcessingPayment = false
-        if not ok then
-            paidOk = false
-            self:log("settlePendingMonthlyAccrual: addMoney error farm %d: %s", farmId, tostring(err))
+        if self:_billFullyResolved(bill) then
+            self.salaryBills[billId] = nil
         end
     end
 
-    if not paidOk then
-        return  -- keep the accrual and retry next tick
+    if paidTotal > 0 then
+        self.declinedLastMonth = false
+        self:log("Settled pending monthly accrual after mode switch: %d (%d farm(s))", paidTotal, paidFarms)
+        if self.settings.showNotifications then
+            local money = g_i18n and g_i18n:formatMoney(paidTotal, 0, true, true) or tostring(paidTotal)
+            self:showNotification("Worker Salary Settled",
+                string.format("Pending monthly wages settled: -%s", money))
+        end
+    end
+end
+
+-- ─────────────────────────────────────────────────────────
+-- F223: native MP-to-SP farm conversion remap
+-- ─────────────────────────────────────────────────────────
+
+--- Apply the native g_farmManager.mergedFarms (old -> surviving id) map to OUR own
+--- obligations exactly once, before the owner is considered ready. Native cash/loan
+--- pooling already happened in the engine; this remaps only WorkerCosts' attributed
+--- accrual and frozen bill parts. Part identity and paid/indeterminate markers survive,
+--- so a repeated map (or reload) cannot pool the same amount twice. Only genuinely
+--- mapped origins with a real surviving target move; a missing farm alone is not a map.
+---@param mergedFarms table|nil  { [oldFarmId] = survivingFarmId }
+function WorkerSystem:remapMergedFarms(mergedFarms)
+    if type(mergedFarms) ~= "table" then return end
+
+    -- Accrual: move a mapped farm's worker rows onto the surviving farm. Equal worker
+    -- keys (same pricing/consumption identity) combine additively; distinct keys stay
+    -- distinct. Legacy-unassigned money is NOT made attributable by this map.
+    local moves = {}
+    for oldFarmId in pairs(self.monthlyCosts or {}) do
+        local target = mergedFarms[oldFarmId]
+        if target ~= nil and target ~= oldFarmId and self:_isRealFarmId(target) then
+            moves[oldFarmId] = target
+        end
+    end
+    for oldFarmId, target in pairs(moves) do
+        local src = self.monthlyCosts[oldFarmId]
+        self.monthlyCosts[oldFarmId] = nil
+        local dst = self.monthlyCosts[target] or {}
+        for key, entry in pairs(src or {}) do
+            if entry and entry.amount and entry.amount > 0 then
+                local existing = dst[key]
+                if existing then existing.amount = existing.amount + entry.amount
+                else dst[key] = { name = entry.name, amount = entry.amount } end
+            end
+        end
+        self.monthlyCosts[target] = dst
     end
 
-    self:log("Settled pending monthly accrual after mode switch: %d", total)
-    if self.settings.showNotifications then
-        local money = g_i18n and g_i18n:formatMoney(total, 0, true, true) or tostring(total)
-        self:showNotification("Worker Salary Settled",
-            string.format("Pending monthly wages settled: -%s", money))
+    -- Bill parts: retarget each part's farmId. Because parts are a list, two parts now
+    -- belonging to one farm simply coexist and are each consumed exactly once; a PAID
+    -- part keeps its status and is never revived. Original id is preserved as provenance.
+    for _, bill in pairs(self.salaryBills or {}) do
+        for _, part in ipairs(bill.parts or {}) do
+            local target = mergedFarms[part.farmId]
+            if target ~= nil and target ~= part.farmId and self:_isRealFarmId(target) then
+                part.originFarmId = part.originFarmId or part.farmId
+                part.farmId = target
+            end
+        end
+    end
+end
+
+-- ─────────────────────────────────────────────────────────
+-- F223 / C3: pure payroll obligation reader (for the emergency-loan forecast)
+-- ─────────────────────────────────────────────────────────
+
+WorkerSystem.PAYROLL_CONTRACT_VERSION = 1
+
+--- Pure, server-only reader. Returns a COPIED version-1 snapshot of this farm's dated
+--- payroll cash obligations inside the supplied one-period horizon. It NEVER mutates
+--- payroll state, issues, pays, flushes open work or migrates (Direction 10/12). Issued
+--- unpaid bills are due-now cash events (clamped to asOf); unbilled measured work is
+--- placed once at its next payable last-day boundary (FIRST_OWNER_CHECK midnight), and
+--- future continuation is declared a coverage gap rather than invented. The shared date
+--- contract: dueDay = native monotonic day, dueTimeMs = ms since midnight.
+---@param farmId number
+---@param horizon table  { asOf = {monotonicDay, timeOfDayMs}, horizonEnd = {monotonicDay, timeOfDayMs}, daysPerPeriod, dayInPeriod }
+---@return table  version-1 payroll obligations snapshot (copied; never aliases live state)
+function WorkerSystem:getPayrollObligations(farmId, horizon)
+    local enabled = (self.settings and self.settings.monthlySalaryEnabled) == true
+    local result = {
+        version         = WorkerSystem.PAYROLL_CONTRACT_VERSION,
+        status          = "UNAVAILABLE",
+        farmId          = farmId,
+        asOf            = nil,
+        enabled         = enabled,
+        settlementMode  = enabled and "MONTHLY" or "IMMEDIATE",
+        coverageReasons = {},
+        events          = {},
+    }
+    local function gap(reason) result.coverageReasons[#result.coverageReasons + 1] = reason end
+
+    if g_currentMission == nil or g_currentMission.getIsServer == nil or not g_currentMission:getIsServer() then
+        gap("NOT_SERVER")
+        return result
+    end
+    if not self:_isRealFarmId(farmId) then
+        gap("INVALID_FARM")
+        return result
     end
 
-    self.monthlyCosts      = {}
-    self.declinedLastMonth = false
+    -- Validate the supplied date contract; an invalid clock is unavailable, not zero.
+    local asOf = horizon and horizon.asOf
+    if type(asOf) ~= "table" or type(asOf.monotonicDay) ~= "number" or type(asOf.timeOfDayMs) ~= "number"
+        or asOf.monotonicDay < 0 or asOf.monotonicDay % 1 ~= 0
+        or asOf.timeOfDayMs < 0 or asOf.timeOfDayMs >= 86400000 then
+        gap("INVALID_ASOF")
+        return result
+    end
+    result.asOf = { monotonicDay = asOf.monotonicDay, timeOfDayMs = asOf.timeOfDayMs }
+
+    local daysPerPeriod = horizon.daysPerPeriod
+    local dayInPeriod   = horizon.dayInPeriod
+    local endDay        = horizon.horizonEnd and horizon.horizonEnd.monotonicDay
+    local endTimeMs     = horizon.horizonEnd and horizon.horizonEnd.timeOfDayMs
+
+    local function withinHorizon(dueDay, dueTimeMs)
+        if type(endDay) ~= "number" then return true end
+        if dueDay < endDay then return true end
+        if dueDay > endDay then return false end
+        return dueTimeMs <= (endTimeMs or 0)
+    end
+
+    -- 1) Issued unpaid bills for this farm: due now, clamped to asOf.
+    for _, bill in pairs(self.salaryBills or {}) do
+        local sum, indeterminate = 0, false
+        for _, part in ipairs(bill.parts or {}) do
+            if part.farmId == farmId then
+                if part.status == WorkerSystem.PART_UNPAID and (part.remaining or 0) > 0 then
+                    sum = sum + part.remaining
+                elseif part.status == WorkerSystem.PART_INDETERMINATE then
+                    indeterminate = true
+                end
+            end
+        end
+        if indeterminate then gap("BILL_INDETERMINATE") end
+        if sum > 0 and withinHorizon(asOf.monotonicDay, asOf.timeOfDayMs) then
+            result.events[#result.events + 1] = {
+                sourceKey       = "payroll:bill:" .. tostring(bill.id),
+                dueDay          = asOf.monotonicDay,
+                dueTimeMs       = asOf.timeOfDayMs,
+                timingBasis     = "ISSUED_DUE_NOW",
+                fixedAmount     = sum,
+                estimatedAmount = 0,
+                basis           = "ISSUED_BILL",
+                componentIds    = { "bill:" .. tostring(bill.id) },
+            }
+        end
+    end
+
+    -- 2) Unbilled measured accrual for this farm: one event at the next payable last day
+    -- (or due-now at asOf if today is the last day and this period has not yet issued).
+    local accruedNow = 0
+    local farmBook = self.monthlyCosts[farmId]
+    if farmBook then
+        for _, entry in pairs(farmBook) do
+            if entry and entry.amount and entry.amount > 0 then accruedNow = accruedNow + entry.amount end
+        end
+    end
+    if accruedNow > 0 then
+        if type(daysPerPeriod) == "number" and type(dayInPeriod) == "number"
+            and daysPerPeriod >= 1 and dayInPeriod >= 1 and dayInPeriod <= daysPerPeriod then
+            local offset = daysPerPeriod - dayInPeriod
+            if offset == 0 then
+                -- Today is the last day; if this period already issued, the next payable
+                -- boundary is a full period out, not another due-now bill.
+                local env = g_currentMission.environment
+                if env and type(env.currentYear) == "number" and type(env.currentPeriod) == "number" then
+                    local ordinal = WorkerSystem._issuanceOrdinal(env.currentYear, env.currentPeriod)
+                    if self.lastIssuedOrdinal == ordinal then
+                        offset = daysPerPeriod
+                    end
+                end
+            end
+            local dueDay    = asOf.monotonicDay + offset
+            local dueTimeMs = (offset == 0) and asOf.timeOfDayMs or 0  -- FIRST_OWNER_CHECK midnight
+            if withinHorizon(dueDay, dueTimeMs) then
+                result.events[#result.events + 1] = {
+                    sourceKey       = "payroll:unbilled:" .. tostring(farmId),
+                    dueDay          = dueDay,
+                    dueTimeMs       = dueTimeMs,
+                    timingBasis     = (offset == 0) and "DUE_NOW" or "FIRST_OWNER_CHECK",
+                    fixedAmount     = accruedNow,
+                    estimatedAmount = 0,
+                    basis           = "UNBILLED_MEASURED",
+                    componentIds    = { "unbilled" },
+                }
+            end
+            -- Future crew continuation needs live job area; declare the gap, never invent.
+            gap("FUTURE_CONTINUATION_UNESTIMATED")
+        else
+            gap("NO_CALENDAR_FOR_UNBILLED")
+        end
+    end
+
+    -- Sort events by due day/time for a stable consumer view.
+    table.sort(result.events, function(a, b)
+        if a.dueDay ~= b.dueDay then return a.dueDay < b.dueDay end
+        return a.dueTimeMs < b.dueTimeMs
+    end)
+
+    result.status = (#result.coverageReasons > 0) and "PARTIAL" or "OK"
+    return result
 end

--- a/tools/test/lib.mjs
+++ b/tools/test/lib.mjs
@@ -1,0 +1,42 @@
+// Shared helpers for the FS25_SoilFertilizer test tooling.
+import { readdirSync, statSync } from "node:fs";
+import { join, resolve, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+
+// Repo root is two levels up from tools/test/
+export const REPO_ROOT = resolve(__dirname, "..", "..");
+export const SRC_DIR = join(REPO_ROOT, "src");
+
+/** Recursively collect every *.lua file under `dir`. */
+export function findLuaFiles(dir = SRC_DIR) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      out.push(...findLuaFiles(full));
+    } else if (entry.endsWith(".lua")) {
+      out.push(full);
+    }
+  }
+  return out.sort();
+}
+
+/** Path relative to repo root, with forward slashes (clickable in terminals). */
+export function rel(p) {
+  return relative(REPO_ROOT, p).replace(/\\/g, "/");
+}
+
+// Minimal ANSI colour (skipped when not a TTY).
+const useColor = process.stdout.isTTY;
+const wrap = (code) => (s) => (useColor ? `\x1b[${code}m${s}\x1b[0m` : s);
+export const c = {
+  red: wrap("31"),
+  green: wrap("32"),
+  yellow: wrap("33"),
+  cyan: wrap("36"),
+  dim: wrap("2"),
+  bold: wrap("1"),
+};

--- a/tools/test/lua/RSF-F223-payroll_owner_contract_test.lua
+++ b/tools/test/lua/RSF-F223-payroll_owner_contract_test.lua
@@ -1,0 +1,524 @@
+--!load: src/settings/Settings.lua, src/WorkerSystem.lua
+-- RSF-F223 v0.2 / F225: payroll owner contract, Stage 3 proof DRAFT.
+-- Authoring only. This file has NOT been run as part of its drafting task.
+--
+-- Design input:
+-- E:/FS25 workspaceC/Engineering Office/mods/FS25_WorkerCosts/build-briefs/
+-- RSF-F223-payroll-calendar-and-farm-bills-IMPLEMENTATION-BRIEF.md (v0.2).
+-- Source evidence:
+-- E:/FS25 workspaceC/Crew Office/Returns/Source Reads/
+-- C3-WORKER-BILL-CONTRACT-2026-09-11.md.
+--
+-- GROUP A calls the actual loaded WorkerSystem methods on controlled fixtures.
+-- It witnesses the current short-month miss and shared-worker farm pooling.
+-- These are defect witnesses, NOT assertions that the repaired source is built.
+-- When the repair changes them, replace the witnesses with production regression
+-- calls. Do not loosen a failed witness merely to keep this draft green.
+--
+-- GROUPS B-D are small REFERENCE CONTRACT MODELS, not WorkerCosts implementation.
+-- Calendar, farms, bill state and payment outcomes are synthetic and XML-free.
+-- Amount fixtures are already-valued work/final bill amounts. No model calculates
+-- a new wage, penalty, fee or refund. Existing Pay/Escape, explicit Decline and
+-- pricing policy remain with the owner; these models begin after Pay was chosen.
+-- An actor returning "applied" below is a synthetic confirmed outcome, NOT the
+-- native addMoney return contract. No native transfer acknowledgement is proved.
+--
+-- Not covered: native saves, migration of a real XML file, lost historical farm
+-- shares, UI/permissions, real multiplayer, Time Guard delivery, live job timing,
+-- the final getPayrollObligations schema, or gameplay. No independent review claim.
+--
+-- Load dependency read: both modules only need the prelude's Class at top level.
+-- The logger below is a test-local fixture for Settings.new, not a prelude edit.
+
+T.ok("F223 A0 actual Settings module loaded", type(Settings) == "table")
+T.ok("F223 A0 actual WorkerSystem module loaded", type(WorkerSystem) == "table")
+if type(Settings) ~= "table" or type(WorkerSystem) ~= "table" then
+    T.summary()
+    return
+end
+
+-- GROUP A: REAL SOURCE, mocked calendar, logger and money destination only.
+local savedMission, savedLogging, savedFarmManager = g_currentMission, Logging, FarmManager
+Logging = { info = function() end, warning = function() end, error = function() end }
+FarmManager = { SPECTATOR_FARM_ID = 0, GUIDED_TOUR_FARM_ID = 14, INVALID_FARM_ID = 15 }
+
+local sourceSettings = Settings.new(nil)
+sourceSettings.enabled = true
+sourceSettings.debugMode = false
+sourceSettings.monthlySalaryEnabled = true
+
+local sourceMoneyCalls = 0
+g_currentMission = {
+    environment = {
+        currentYear = 1, currentPeriod = 1, currentDay = 3,
+        currentMonotonicDay = 3, currentDayInPeriod = 3, daysPerPeriod = 3,
+    },
+    getFarmId = function() return 9 end,
+    getIsServer = function() return true end,
+    addMoney = function() sourceMoneyCalls = sourceMoneyCalls + 1 end,
+}
+
+-- REPAIRED REGRESSIONS (replacing the pre-repair defect witnesses A1/A2/A8-A10).
+-- F130/F223 changed checkMonthEnd to fire on the native last day of any month length
+-- and chargeWage to accrue per farm, so the old witnesses must assert the fixed
+-- behaviour, not the defect (per the file header: do not loosen, re-point).
+local sourceCalendar = WorkerSystem.new(sourceSettings, nil)
+local sourceIssues, sourceIssuedMonth = 0, nil
+-- Replace only the downstream UI/mutating issue action. checkMonthEnd is REAL.
+sourceCalendar.triggerMonthlySalaryDialog = function(_, month)
+    sourceIssues = sourceIssues + 1
+    sourceIssuedMonth = month
+end
+sourceCalendar:checkMonthEnd()
+T.eq("F223 A1 REPAIRED three-day month issues its bill on the real last day", sourceIssues, 1)
+T.eq("F223 A2 REPAIRED short-month issuance records the native ordinal", sourceCalendar.lastIssuedOrdinal, 1 * 12 + 1 - 1)
+T.eq("F223 A2b REPAIRED issue receives the actual period", sourceIssuedMonth, 1)
+
+-- The SAME (year, period) re-checked at a different month length does not re-issue.
+g_currentMission.environment.currentDay = 28
+g_currentMission.environment.currentMonotonicDay = 28
+g_currentMission.environment.currentDayInPeriod = 28
+g_currentMission.environment.daysPerPeriod = 28
+sourceCalendar:checkMonthEnd()
+T.eq("F223 A3 REPAIRED repeated same-period check issues once", sourceIssues, 1)
+
+-- A later period issues again (the ordinal marker is not a one-shot lock).
+g_currentMission.environment.currentPeriod = 2
+g_currentMission.environment.currentDayInPeriod = 28
+g_currentMission.environment.daysPerPeriod = 28
+sourceCalendar:checkMonthEnd()
+T.eq("F223 A4 REPAIRED a new period issues again", sourceIssues, 2)
+T.eq("F223 A5 REPAIRED new issue carries the new period", sourceIssuedMonth, 2)
+sourceCalendar:checkMonthEnd()
+T.eq("F223 A6 REPAIRED repeated new-period check issues once", sourceIssues, 2)
+
+-- chargeWage now keeps each farm's share of a shared worker distinct (no pooling).
+local sourcePayroll = WorkerSystem.new(sourceSettings, nil)
+local sharedWorker = 77
+T.eq("F223 A7 REPAIRED first farm measured wage is accepted",
+    sourcePayroll:chargeWage(sharedWorker, "Shared worker", 100, "fixture", true, 1), true)
+T.eq("F223 A8 REPAIRED second farm measured wage is accepted",
+    sourcePayroll:chargeWage(sharedWorker, "Shared worker", 200, "fixture", true, 2), true)
+local farm1Book, farm2Book = sourcePayroll.monthlyCosts[1], sourcePayroll.monthlyCosts[2]
+T.ok("F223 A9 REPAIRED farm one holds its own worker entry", farm1Book ~= nil and farm1Book["77"] ~= nil)
+T.ok("F223 A10 REPAIRED farm two holds its own worker entry", farm2Book ~= nil and farm2Book["77"] ~= nil)
+T.near("F223 A11 REPAIRED farm one keeps exactly its 100", farm1Book and farm1Book["77"] and farm1Book["77"].amount, 100, 0)
+T.near("F223 A12 REPAIRED farm two keeps exactly its 200", farm2Book and farm2Book["77"] and farm2Book["77"].amount, 200, 0)
+T.eq("F223 A13 REPAIRED no pooled entry lives under the worker id", sourcePayroll.monthlyCosts[sharedWorker], nil)
+sourcePayroll:chargeWage(78, "Separate worker", 40, "fixture", true, 2)
+T.near("F223 A14 REPAIRED a different worker retains its own farm-two amount",
+    sourcePayroll.monthlyCosts[2] and sourcePayroll.monthlyCosts[2]["78"] and sourcePayroll.monthlyCosts[2]["78"].amount, 40, 0)
+T.eq("F223 A15 REPAIRED monthly accrual fixtures never invoke addMoney", sourceMoneyCalls, 0)
+
+g_currentMission, Logging, FarmManager = savedMission, savedLogging, savedFarmManager
+
+-- GROUP A2: REAL-SOURCE regression of the repaired bill lifecycle (freeze -> pay) and
+-- the pure getPayrollObligations reader. Drives the actual WorkerSystem methods.
+do
+    local savedM, savedL, savedFM = g_currentMission, Logging, FarmManager
+    Logging = { info = function() end, warning = function() end, error = function() end }
+    FarmManager = { SPECTATOR_FARM_ID = 0, GUIDED_TOUR_FARM_ID = 14, INVALID_FARM_ID = 15 }
+    local moves = {}
+    g_currentMission = {
+        environment = { currentYear = 1, currentPeriod = 3, currentDay = 3,
+            currentMonotonicDay = 3, currentDayInPeriod = 3, daysPerPeriod = 3, dayTime = 0 },
+        getFarmId = function() return 1 end,
+        getIsServer = function() return true end,
+        addMoney = function(_, amount, farmId) moves[#moves + 1] = { amount = amount, farmId = farmId } end,
+    }
+
+    local s = Settings.new(nil)
+    s.enabled = true; s.debugMode = false; s.monthlySalaryEnabled = true; s.showNotifications = false
+    local ws = WorkerSystem.new(s, nil)
+    ws:chargeWage("w1", "Ann", 100, "fixture", true, 1)
+    ws:chargeWage("w2", "Bob", 200, "fixture", true, 2)
+
+    -- Pre-freeze: unbilled measured work is placed once at the next payable last day
+    -- (FIRST_OWNER_CHECK midnight), and the reader is PARTIAL (future crew work is not
+    -- estimated). Mid-period horizon (dayInPeriod 1 of 3) -> offset 2 days.
+    local midHorizon = { asOf = { monotonicDay = 3, timeOfDayMs = 0 },
+        horizonEnd = { monotonicDay = 6, timeOfDayMs = 0 }, daysPerPeriod = 3, dayInPeriod = 1 }
+    local pvPre = ws:getPayrollObligations(1, midHorizon)
+    T.near("F223 A2-pre1 unbilled amount is farm one's own 100", pvPre.events[1] and pvPre.events[1].fixedAmount, 100, 0)
+    T.eq("F223 A2-pre2 unbilled is placed at the next last day", pvPre.events[1] and pvPre.events[1].dueDay, 5)
+    T.eq("F223 A2-pre3 unbilled due time is midnight", pvPre.events[1] and pvPre.events[1].dueTimeMs, 0)
+    T.eq("F223 A2-pre4 unbilled timing basis is FIRST_OWNER_CHECK", pvPre.events[1] and pvPre.events[1].timingBasis, "FIRST_OWNER_CHECK")
+    T.eq("F223 A2-pre5 reader is PARTIAL when future continuation is unestimated", pvPre.status, "PARTIAL")
+
+    local bill = ws:_freezeMonthlyBill(3)
+    T.ok("F223 A2-1 freeze creates a bill with two per-farm parts", bill ~= nil and #bill.parts == 2)
+    T.ok("F223 A2-2 accrual is cleared once frozen", not ws:_hasAccrual())
+
+    local horizon = { asOf = { monotonicDay = 3, timeOfDayMs = 0 },
+        horizonEnd = { monotonicDay = 6, timeOfDayMs = 0 }, daysPerPeriod = 3, dayInPeriod = 3 }
+    local pv1 = ws:getPayrollObligations(1, horizon)
+    T.eq("F223 A2-3 reader reports OK with an issued bill", pv1.status, "OK")
+    T.eq("F223 A2-4 farm one has exactly one due-now event", #pv1.events, 1)
+    T.near("F223 A2-5 farm one due-now amount is its own 100", pv1.events[1].fixedAmount, 100, 0)
+    T.eq("F223 A2-6 issued bill is due at asOf day", pv1.events[1].dueDay, 3)
+    T.eq("F223 A2-7 issued bill timing basis is due-now", pv1.events[1].timingBasis, "ISSUED_DUE_NOW")
+    T.near("F223 A2-8 farm two due-now amount is its own 200",
+        ws:getPayrollObligations(2, horizon).events[1].fixedAmount, 200, 0)
+    local pvOther = ws:getPayrollObligations(5, horizon)
+    T.eq("F223 A2-9 an uninvolved farm gets no payroll event", #pvOther.events, 0)
+
+    -- Pay the frozen bill by its exact id.
+    ws.pendingSalary = { billId = bill.id, month = 3 }
+    ws:executeMonthlySalaryPayment()
+    local paid = {}
+    for _, m in ipairs(moves) do paid[m.farmId] = (paid[m.farmId] or 0) + m.amount end
+    T.near("F223 A2-10 farm one charged exactly -100", paid[1], -100, 0)
+    T.near("F223 A2-11 farm two charged exactly -200", paid[2], -200, 0)
+    T.eq("F223 A2-12 a fully paid bill is retired", ws.salaryBills[bill.id], nil)
+    T.eq("F223 A2-13 reader reports nothing after payment", #ws:getPayrollObligations(1, horizon).events, 0)
+
+    g_currentMission, Logging, FarmManager = savedM, savedL, savedFM
+end
+
+-- GROUP A3: REAL-SOURCE regression of Decline — unpaid base rows return to accrual
+-- (pre-penalty), and the next bill applies the floor(base*1.20) penalty exactly once.
+do
+    local savedM, savedL, savedFM = g_currentMission, Logging, FarmManager
+    Logging = { info = function() end, warning = function() end, error = function() end }
+    FarmManager = { SPECTATOR_FARM_ID = 0, GUIDED_TOUR_FARM_ID = 14, INVALID_FARM_ID = 15 }
+    g_currentMission = {
+        environment = { currentYear = 1, currentPeriod = 3, currentDay = 3,
+            currentMonotonicDay = 3, currentDayInPeriod = 3, daysPerPeriod = 3, dayTime = 0 },
+        getFarmId = function() return 1 end,
+        getIsServer = function() return true end,
+        addMoney = function() end,
+    }
+    local s = Settings.new(nil)
+    s.enabled = true; s.debugMode = false; s.monthlySalaryEnabled = true; s.showNotifications = false
+    local ws = WorkerSystem.new(s, nil)
+    ws:chargeWage("w1", "Ann", 100, "fixture", true, 1)
+    local bill = ws:_freezeMonthlyBill(3)
+    ws.pendingSalary = { billId = bill.id, total = 100, month = 3 }
+    ws:declineMonthlySalary()
+    T.ok("F223 A3-1 decline sets the next-bill penalty flag", ws.declinedLastMonth == true)
+    T.ok("F223 A3-2 unpaid base rows return to live accrual", ws:_hasAccrual())
+    T.near("F223 A3-3 returned amount is the pre-penalty base",
+        ws.monthlyCosts[1] and ws.monthlyCosts[1]["w1"] and ws.monthlyCosts[1]["w1"].amount, 100, 0)
+    T.eq("F223 A3-4 the declined bill is retired", ws.salaryBills[bill.id], nil)
+    local bill2 = ws:_freezeMonthlyBill(4)
+    T.near("F223 A3-5 next bill applies floor(base*1.20) once", bill2.parts[1].final, 120, 0)
+    T.near("F223 A3-6 next bill keeps the base pre-penalty", bill2.parts[1].base, 100, 0)
+    T.ok("F223 A3-7 penalty flag clears after it is baked into a bill", ws.declinedLastMonth == false)
+    g_currentMission, Logging, FarmManager = savedM, savedL, savedFM
+end
+
+-- GROUP B: REFERENCE ONLY. Last-day issuance on a synthetic 12-period calendar.
+-- This deliberately does not replace the real native/TG scheduling proof.
+local MODEL_PERIODS_IN_YEAR = 12
+local function newOwner()
+    return { accrued = {}, bills = {}, lastIssuedOrdinal = nil, serial = 0 }
+end
+
+local function accrue(owner, farmId, workerId, amount)
+    owner.accrued[farmId] = owner.accrued[farmId] or {}
+    local key = tostring(workerId)
+    owner.accrued[farmId][key] = (owner.accrued[farmId][key] or 0) + amount
+end
+
+local function sumEntries(entries)
+    local total = 0
+    for _, amount in pairs(entries or {}) do total = total + amount end
+    return total
+end
+
+local function issueOnLastDay(owner, calendar)
+    if calendar.dayInPeriod ~= calendar.daysPerPeriod then return nil end
+    local ordinal = calendar.year * MODEL_PERIODS_IN_YEAR + calendar.period - 1
+    if owner.lastIssuedOrdinal ~= nil and ordinal <= owner.lastIssuedOrdinal then return nil end
+    owner.lastIssuedOrdinal = ordinal
+    owner.serial = owner.serial + 1
+    local bill = { id = owner.serial, quotedByFarm = {}, remainingByFarm = {} }
+    for farmId, entries in pairs(owner.accrued) do
+        local amount = sumEntries(entries)
+        if amount > 0 then
+            bill.quotedByFarm[farmId] = amount
+            bill.remainingByFarm[farmId] = amount
+        end
+    end
+    owner.accrued = {} -- Cut only this snapshot; later work starts separately.
+    owner.bills[bill.id] = bill
+    return bill
+end
+
+for _, days in ipairs({ 1, 3, 28 }) do
+    local owner = newOwner()
+    accrue(owner, 1, 10, 90)
+    local issued = 0
+    for day = 1, days do
+        local calendar = { year = 2, period = 12, dayInPeriod = day, daysPerPeriod = days }
+        local bill = issueOnLastDay(owner, calendar)
+        if bill then issued = issued + 1 end
+        T.eq("F223 B1 MODEL D=" .. days .. " day=" .. day .. " issues only on last day",
+            bill ~= nil, day == days)
+        T.eq("F223 B2 MODEL D=" .. days .. " day=" .. day .. " repeated check cannot issue again",
+            issueOnLastDay(owner, calendar), nil)
+    end
+    T.eq("F223 B3 MODEL D=" .. days .. " exactly one issuance in the period", issued, 1)
+    accrue(owner, 1, 10, 25)
+    local nextBill = issueOnLastDay(owner,
+        { year = 3, period = 1, dayInPeriod = days, daysPerPeriod = days })
+    T.ok("F223 B4 MODEL D=" .. days .. " year rollover allows next due period", nextBill ~= nil)
+    T.eq("F223 B5 MODEL D=" .. days .. " rollover quotes only later work",
+        nextBill and nextBill.quotedByFarm[1], 25)
+    T.eq("F223 B6 MODEL D=" .. days .. " old period cannot replay after rollover",
+        issueOnLastDay(owner, { year = 2, period = 12, dayInPeriod = days, daysPerPeriod = days }), nil)
+end
+
+-- First observation can be on the due day: no simulated prior tick is required.
+local loadedDayOwner = newOwner()
+accrue(loadedDayOwner, 2, 10, 17)
+local loadedDayBill = issueOnLastDay(loadedDayOwner,
+    { year = 4, period = 7, dayInPeriod = 3, daysPerPeriod = 3 })
+T.eq("F223 B7 MODEL first authoritative observation on due day can issue",
+    loadedDayBill and loadedDayBill.quotedByFarm[2], 17)
+
+-- GROUP C: REFERENCE ONLY. Immutable quotes and per-farm payment consumption.
+-- This is an in-memory state cut, not a native transaction/acknowledgement API.
+local function copyAmounts(amounts)
+    local copy = {}
+    for farmId, amount in pairs(amounts) do copy[farmId] = amount end
+    return copy
+end
+
+local function readBill(owner, billId)
+    local bill = owner.bills[billId]
+    if not bill then return nil end
+    return { id = bill.id, quotedByFarm = copyAmounts(bill.quotedByFarm),
+        remainingByFarm = copyAmounts(bill.remainingByFarm) }
+end
+
+local function settleChosenBill(owner, billId, actor)
+    local bill = owner.bills[billId]
+    if not bill then return 0 end
+    local farmIds = {}
+    for farmId in pairs(bill.remainingByFarm) do farmIds[#farmIds + 1] = farmId end
+    table.sort(farmIds) -- Deliberately exercise first-farm success, later-farm failure.
+    local consumed = 0
+    for _, farmId in ipairs(farmIds) do
+        local amount = bill.remainingByFarm[farmId]
+        bill.indeterminate = bill.indeterminate or {}
+        if not bill.indeterminate[farmId] then
+            local outcome = actor(farmId, amount)
+            if outcome == "applied" then
+                bill.remainingByFarm[farmId] = nil
+                consumed = consumed + amount
+            elseif outcome == "indeterminate" then
+                bill.indeterminate[farmId] = true
+            end
+        end
+    end
+    return consumed
+end
+
+local owner = newOwner()
+accrue(owner, 1, "same-worker", 100)
+accrue(owner, 2, "same-worker", 200)
+T.eq("F223 C1 MODEL same worker keeps farm one's amount separate", sumEntries(owner.accrued[1]), 100)
+T.eq("F223 C2 MODEL same worker keeps farm two's amount separate", sumEntries(owner.accrued[2]), 200)
+local bill = issueOnLastDay(owner, { year = 5, period = 4, dayInPeriod = 3, daysPerPeriod = 3 })
+accrue(owner, 1, "same-worker", 55)
+T.eq("F223 C3 MODEL later wages do not change the displayed farm-one quote", bill.quotedByFarm[1], 100)
+T.eq("F223 C4 MODEL later wages remain separate from the issued bill", sumEntries(owner.accrued[1]), 55)
+local read = readBill(owner, bill.id)
+read.quotedByFarm[1] = 999
+read.remainingByFarm[2] = 0
+T.eq("F223 C5 MODEL returned quote cannot mutate owner's frozen amount", bill.quotedByFarm[1], 100)
+T.eq("F223 C6 MODEL returned quote cannot erase another farm's debt", bill.remainingByFarm[2], 200)
+T.eq("F223 C7 MODEL reading has not consumed later accrued work", sumEntries(owner.accrued[1]), 55)
+
+local cash, attempts, failFarmTwo = { [1] = 1000, [2] = 1000 }, {}, true
+local function syntheticActor(farmId, amount)
+    attempts[farmId] = (attempts[farmId] or 0) + 1
+    if farmId == 2 and failFarmTwo then return "failed" end
+    cash[farmId] = cash[farmId] - amount
+    return "applied"
+end
+T.eq("F223 C8 MODEL first attempt consumes only successful farm", settleChosenBill(owner, bill.id, syntheticActor), 100)
+T.eq("F223 C9 MODEL successful farm's pending portion is removed", bill.remainingByFarm[1], nil)
+T.eq("F223 C10 MODEL failed farm's exact amount remains due", bill.remainingByFarm[2], 200)
+T.eq("F223 C11 MODEL failed farm has no synthetic cash movement", cash[2], 1000)
+T.eq("F223 C12 MODEL first-farm success preserves newly accrued wages", sumEntries(owner.accrued[1]), 55)
+failFarmTwo = false
+T.eq("F223 C13 MODEL retry consumes only the retained farm", settleChosenBill(owner, bill.id, syntheticActor), 200)
+T.eq("F223 C14 MODEL succeeded farm is not attempted again", attempts[1], 1)
+T.eq("F223 C15 MODEL failed then succeeded farm is attempted twice", attempts[2], 2)
+T.eq("F223 C16 MODEL farm one's exact charge occurs once", cash[1], 900)
+T.eq("F223 C17 MODEL farm two's exact charge occurs once", cash[2], 800)
+T.eq("F223 C18 MODEL repeat after payment consumes nothing", settleChosenBill(owner, bill.id, syntheticActor), 0)
+T.eq("F223 C19 MODEL completed-bill retry does not call successful farm again", attempts[1], 1)
+T.eq("F223 C20 MODEL all payment attempts leave later wages untouched", sumEntries(owner.accrued[1]), 55)
+T.eq("F223 C21 MODEL immutable displayed quote survives consumption", bill.quotedByFarm[2], 200)
+
+local unknownOwner = newOwner()
+accrue(unknownOwner, 1, 1, 31)
+local unknownBill = issueOnLastDay(unknownOwner,
+    { year = 1, period = 1, dayInPeriod = 1, daysPerPeriod = 1 })
+T.eq("F223 C22 MODEL indeterminate outcome does not count as applied",
+    settleChosenBill(unknownOwner, unknownBill.id, function() return "indeterminate" end), 0)
+T.eq("F223 C23 MODEL indeterminate amount remains retained", unknownBill.remainingByFarm[1], 31)
+local unknownRetryCalls=0
+settleChosenBill(unknownOwner, unknownBill.id, function()
+    unknownRetryCalls=unknownRetryCalls+1
+    return "applied"
+end)
+T.eq("F223 C24 MODEL unknown cash effect prevents automatic retry",unknownRetryCalls,0)
+T.eq("F223 C25 MODEL blocked uncertain amount is not treated as paid",unknownBill.remainingByFarm[1],31)
+
+-- GROUP D: REFERENCE ONLY. Preserve raw legacy facts, never reconstruct shares.
+-- Rows below are synthetic decoded records. No XML parser or save/load is tested.
+local function recordedRealFarm(farmId)
+    return type(farmId) == "number" and farmId > 0 and farmId % 1 == 0
+        and farmId ~= 14 and farmId ~= 15
+end
+
+local function preserveLegacyRows(rows)
+    local retained = { byFarm = {}, unattributed = {}, evidence = {} }
+    for _, row in ipairs(rows) do
+        local copy = { id = row.id, name = row.name, amount = row.amount,
+            recordedFarmId = row.farmId, provenance = "legacy-recorded" }
+        retained.evidence[#retained.evidence + 1] = copy
+        if recordedRealFarm(row.farmId) then
+            retained.byFarm[row.farmId] = retained.byFarm[row.farmId] or {}
+            local key = tostring(row.id)
+            retained.byFarm[row.farmId][key] = (retained.byFarm[row.farmId][key] or 0) + row.amount
+        else
+            retained.unattributed[#retained.unattributed + 1] = copy
+        end
+    end
+    return retained
+end
+
+local legacy = preserveLegacyRows({
+    { id = 42, name = "Recorded worker", amount = 90, farmId = 7 },
+    { id = "42", name = "Recorded worker", amount = 10, farmId = 7 },
+    { id = 42, name = "Recorded worker", amount = 35, farmId = 2 },
+    { id = "missing-owner", name = "Unattributed worker", amount = 70 },
+    { id = "invalid-owner", name = "Invalid target", amount = 8, farmId = 15 },
+})
+T.eq("F223 D1 MODEL recorded target survives without today's assignment", sumEntries(legacy.byFarm[7]), 100)
+T.eq("F223 D2 MODEL same worker's separately recorded second farm is retained", sumEntries(legacy.byFarm[2]), 35)
+T.eq("F223 D3 MODEL numeric/string worker keys preserve both recorded amounts", legacy.byFarm[7]["42"], 100)
+T.eq("F223 D4 MODEL no invented share is assigned to farm one", legacy.byFarm[1], nil)
+T.eq("F223 D5 MODEL missing and invalid targets both remain unattributed", #legacy.unattributed, 2)
+T.eq("F223 D6 MODEL unattributed amount is not discarded", legacy.unattributed[1].amount, 70)
+T.eq("F223 D7 MODEL invalid recorded target remains evidence", legacy.unattributed[2].recordedFarmId, 15)
+T.eq("F223 D8 MODEL legacy provenance is explicit", legacy.evidence[1].provenance, "legacy-recorded")
+T.eq("F223 D9 MODEL all original rows remain evidence", #legacy.evidence, 5)
+local preservedTotal = sumEntries(legacy.byFarm[7]) + sumEntries(legacy.byFarm[2])
+for _, row in ipairs(legacy.unattributed) do preservedTotal = preservedTotal + row.amount end
+T.near("F223 D10 MODEL attributed plus unattributed total conserves all recorded money",
+    preservedTotal, 90 + 10 + 35 + 70 + 8, 0)
+
+-- A single historical row may already contain several farms' work. Its original
+-- shares are unknowable here: keep the recorded 300 on its recorded target and
+-- preserve the uncertainty, rather than inventing a 150/150 reconstruction.
+local mixedLegacy = preserveLegacyRows({
+    { id = "pooled-before-save", name = "Old pooled worker", amount = 300, farmId = 1 },
+})
+T.eq("F223 D11 MODEL a previously pooled row keeps its whole recorded amount", sumEntries(mixedLegacy.byFarm[1]), 300)
+T.eq("F223 D12 MODEL a previously pooled row does not create a guessed farm-two share", mixedLegacy.byFarm[2], nil)
+
+
+-- R1 coexistence: real old hook under an unsupported missing-wage-enum fixture.
+-- Normal1.23.1.0 supplies AI; this witnesses the conditional heuristic hazard.
+do
+    local oldMission, oldTypes, oldLogging = g_currentMission, MoneyType, Logging
+    MoneyType={OTHER={name="other"}}
+    Logging={info=function()end,warning=function()end,error=function()end}
+    local actual=0
+    g_currentMission={addMoney=function(_,amount) actual=actual+amount end,
+        aiSystem={getActiveJobs=function() return {{}} end}}
+    local hook=setmetatable({settings={enabled=true},log=function()end},{__index=WorkerSystem})
+    hook:installGameHook()
+    g_currentMission:addMoney(-100,1,MoneyType.OTHER)
+    T.eq("R1 REPAIRED typed OTHER is forwarded through the captured chain, not swallowed",actual,-100)
+    -- Small reference predicate is the owner repair, not a bypassed native call.
+    local function shouldSuppress(amount,kind,ai,wage,other)
+        if kind~=nil and kind==other then return false end
+        return amount<0 and ((ai~=nil and kind==ai) or (wage~=nil and kind==wage))
+    end
+    T.eq("R1 REFERENCE typed OTHER passes with missing wage enums",shouldSuppress(-100,MoneyType.OTHER,nil,nil,MoneyType.OTHER),false)
+    local ai={};T.eq("R1 REFERENCE actual AI wage remains suppressed",shouldSuppress(-100,ai,ai,nil,MoneyType.OTHER),true)
+    g_currentMission,MoneyType,Logging=oldMission,oldTypes,oldLogging
+end
+
+
+-- Native conversion preserves bill-part status and identity while retargeting.
+do
+    local parts={{id="bill1/farm1",farm=1,amount=100,status="PAID"},
+                 {id="bill1/farm2",farm=2,amount=200,status="UNPAID"},
+                 {id="bill2/farm2",farm=2,amount=30,status="INDETERMINATE"}}
+    local map={[2]=1}
+    for _,part in ipairs(parts) do part.farm=map[part.farm] or part.farm end
+    local due=0
+    for _,part in ipairs(parts) do if part.farm==1 and part.status=="UNPAID" then due=due+part.amount end end
+    T.eq("R1 merge does not revive an already-paid wage part",due,200)
+    T.eq("R1 unknown payment status survives farm remap",parts[3].status,"INDETERMINATE")
+    T.eq("R1 remapped bill keeps original identity",parts[2].id,"bill1/farm2")
+    for _,part in ipairs(parts) do part.farm=map[part.farm] or part.farm end
+    T.eq("R1 repeated map does not create more bill parts",#parts,3)
+end
+
+-- R3 REFERENCE: producer date fields, missed checks and a rolling horizon.
+-- This models retained bill timing only, not the new native producer/Event/XML.
+do
+    local function payrollView(owner,env,farmId)
+        local day,ms,D=env.currentMonotonicDay,env.dayTime,env.daysPerPeriod
+        if type(day)~="number" or day<0 or day%1~=0 or type(ms)~="number"
+            or ms~=ms or ms<0 or ms>=86400000 then return nil end
+        local result={farmId=farmId,asOf={monotonicDay=day,timeOfDayMs=ms},events={}}
+        for id,bill in pairs(owner.bills) do
+            local amount=bill.remainingByFarm[farmId] or 0
+            if amount>0 then
+                result.events[#result.events+1]={source="bill:"..id,
+                    dueDay=day,dueTimeMs=ms,amount=amount}
+            end
+        end
+        local amount=sumEntries(owner.accrued[farmId])
+        if amount>0 then
+            local ordinal=env.currentYear*12+env.currentPeriod-1
+            local offset=D-env.currentDayInPeriod
+            if offset==0 and owner.lastIssuedOrdinal==ordinal then offset=D end
+            result.events[#result.events+1]={source="unbilled",dueDay=day+offset,
+                dueTimeMs=offset==0 and ms or 0,amount=amount}
+        end
+        table.sort(result.events,function(a,b)
+            if a.dueDay~=b.dueDay then return a.dueDay<b.dueDay end
+            return a.dueTimeMs<b.dueTimeMs
+        end)
+        return result
+    end
+    local owner=newOwner()
+    accrue(owner,7,"worker",90)
+    accrue(owner,8,"other-farm",500)
+    local env={currentYear=2,currentPeriod=4,currentDayInPeriod=1,daysPerPeriod=3,
+        currentMonotonicDay=40,dayTime=64800000}
+    local pending=payrollView(owner,env,7)
+    T.eq("R3 producer excludes another farm's unbilled work",pending.events[1].amount,90)
+    T.eq("R3 producer copies native dayTime into asOf",pending.asOf.timeOfDayMs,64800000)
+    T.eq("R3 missed-check unbilled work stays at next supported last day",pending.events[1].dueDay,42)
+    T.eq("R3 future FIRST_OWNER_CHECK event declares midnight",pending.events[1].dueTimeMs,0)
+    T.eq("R3 missed check does not create a due-now bill",next(owner.bills),nil)
+    T.eq("R3 pure producer read leaves accrued work untouched",sumEntries(owner.accrued[7]),90)
+    env.currentDayInPeriod=3;env.currentMonotonicDay=42
+    issueOnLastDay(owner,{year=2,period=4,dayInPeriod=3,daysPerPeriod=3})
+    accrue(owner,7,"worker",25)
+    local late=payrollView(owner,env,7)
+    T.eq("R3 issued bill and later unbilled work remain distinct",#late.events,2)
+    T.eq("R3 issued unpaid bill is due now",late.events[1].dueDay,42)
+    T.eq("R3 due-now time clamps to asOf",late.events[1].dueTimeMs,64800000)
+    T.eq("R3 later work is payable at the following last day",late.events[2].dueDay,45)
+    T.eq("R3 rolling duration can include two distinct payday events",
+        (late.events[2].dueDay-42)*86400000+late.events[2].dueTimeMs-64800000<=3*86400000,true)
+    T.eq("R3 one old bill is not counted as later work",late.events[1].amount,90)
+    T.eq("R3 later work does not repeat the old bill",late.events[2].amount,25)
+    env.dayTime=86400000
+    T.eq("R3 producer does not fabricate a day at boundary",payrollView(owner,env,7),nil)
+end
+
+T.summary()

--- a/tools/test/lua/prelude.lua
+++ b/tools/test/lua/prelude.lua
@@ -1,0 +1,119 @@
+-- prelude.lua - minimal FS25 engine mock + tiny test framework.
+-- Loaded first by run-tests.mjs, before any src module and the test file itself.
+-- Only stubs what module load + the functions under test actually touch; extend as
+-- new tests need more of the engine surface.
+
+-- ── Lua 5.1 ↔ fengari (5.3) shims ──────────────────────────
+unpack = unpack or table.unpack
+
+-- ── FS25 engine globals (stubs) ────────────────────────────
+-- Class(base): FS25's OO helper. Returns a metatable whose __index chains to base,
+-- which is enough for `setmetatable({}, Class(Foo))` and method dispatch in tests.
+function Class(base)
+  local mt = {}
+  mt.__index = base or mt
+  return mt
+end
+
+function getWorldTranslation(_node) return 0, 0, 0 end
+function getTerrainHeightAtWorldPos(_node, _x, _y, _z) return 0 end
+g_terrainNode = nil
+
+g_currentMission = {
+  time = 1000,
+  environment = { currentDay = 1, daysPerPeriod = 1 },
+  missionInfo = {},
+}
+
+-- MoneyType enum: the emergency loan grants/deducts use MoneyType.OTHER.
+MoneyType = { OTHER = 3 }
+
+g_i18n = { getText = function(_self, key) return key end }
+g_messageCenter = { subscribe = function() end, unsubscribe = function() end, publish = function() end }
+
+-- Logging: IncomeMod logs via Logging.info/warning (engine global).
+Logging = { info = function() end, warning = function() end, error = function() end }
+
+-- Minimal in-memory XML mock: the file handle is a plain table keyed by the XML path
+-- string, enough for save/load round-trip tests. Extend if a test needs more types.
+function setXMLInt(handle, key, value) if handle then handle[key] = value end end
+function getXMLInt(handle, key) if handle then return handle[key] end end
+function setXMLFloat(handle, key, value) if handle then handle[key] = value end end
+function getXMLFloat(handle, key) if handle then return handle[key] end end
+function setXMLString(handle, key, value) if handle then handle[key] = value end end
+function getXMLString(handle, key) if handle then return handle[key] end end
+
+-- Class tables some modules reference at load; harmless empty stubs.
+HookManager = HookManager or { new = function() return {} end }
+
+-- ── FS25 Event system (stubs) ──────────────────────────────
+-- Enough of the Event base + InitEventClass for a module's event classes to load
+-- and for `SomeEvent.new()` / `:writeStream` / `:readStream` to dispatch in tests.
+Event = Event or { new = function(mt) return setmetatable({}, mt) end }
+function InitEventClass(class, name) class.className = name; return class end
+
+-- ── Mock network stream ────────────────────────────────────
+-- A typed FIFO standing in for an FS25 streamId. Every streamWriteX pushes a
+-- {tag,value}; the paired streamReadX pops it and checks the tag. This turns the
+-- classic MP desync bug (write order != read order, wrong width, count drift) into
+-- a local assertion: a correct writeStream/readStream pair drains the FIFO exactly,
+-- with zero type mismatches and zero underflows. No float32 truncation is modelled
+-- (values pass through as Lua doubles), matching the repo's other round-trip tests.
+function _sfMockStream()
+  return { q = {}, r = 1, typeErrors = 0, underflows = 0 }
+end
+
+local function _sfPush(s, tag, v) s.q[#s.q + 1] = { t = tag, v = v } end
+local function _sfPull(s, tag)
+  local e = s.q[s.r]
+  if e == nil then s.underflows = s.underflows + 1; return nil end
+  s.r = s.r + 1
+  if e.t ~= tag then s.typeErrors = s.typeErrors + 1 end
+  return e.v
+end
+
+function streamWriteInt32(s, v)    _sfPush(s, "i32", v) end
+function streamReadInt32(s)         return _sfPull(s, "i32") end
+function streamWriteFloat32(s, v)   _sfPush(s, "f32", v) end
+function streamReadFloat32(s)       return _sfPull(s, "f32") end
+function streamWriteUInt8(s, v)     _sfPush(s, "u8", v) end
+function streamReadUInt8(s)         return _sfPull(s, "u8") end
+function streamWriteString(s, v)    _sfPush(s, "str", v) end
+function streamReadString(s)        return _sfPull(s, "str") end
+function streamWriteBool(s, v)      _sfPush(s, "bool", v and true or false) end
+function streamReadBool(s)          return _sfPull(s, "bool") end
+function streamWriteUIntN(s, v, _n) _sfPush(s, "uN", v) end
+function streamReadUIntN(s, _n)     return _sfPull(s, "uN") end
+
+-- ── tiny test framework ────────────────────────────────────
+-- Results are emitted as ##TEST_ lines that run-tests.mjs parses out of stdout, so
+-- ordinary log noise (SoilLogger.print, etc.) is ignored.
+T = { _pass = 0, _fail = 0 }
+
+local function _pass(name)
+  T._pass = T._pass + 1
+  print("##TEST_PASS " .. name)
+end
+local function _fail(name, msg)
+  T._fail = T._fail + 1
+  print("##TEST_FAIL " .. name .. " :: " .. tostring(msg))
+end
+
+function T.ok(name, cond, msg)
+  if cond then _pass(name) else _fail(name, msg or "expected truthy, got " .. tostring(cond)) end
+end
+
+function T.eq(name, got, want)
+  if got == want then _pass(name)
+  else _fail(name, "got " .. tostring(got) .. " want " .. tostring(want)) end
+end
+
+function T.near(name, got, want, tol)
+  tol = tol or 1e-6
+  if type(got) == "number" and math.abs(got - want) <= tol then _pass(name)
+  else _fail(name, "got " .. tostring(got) .. " want ~" .. tostring(want) .. " (tol " .. tol .. ")") end
+end
+
+function T.summary()
+  print("##TEST_SUMMARY " .. T._pass .. " " .. T._fail)
+end

--- a/tools/test/package.json
+++ b/tools/test/package.json
@@ -3,8 +3,12 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
-  "description": "Lua 5.1 pre-commit gate. Excluded from the mod zip with the rest of tools/.",
+  "description": "Lua 5.1 pre-commit gate + offline contract tests. Excluded from the mod zip with the rest of tools/.",
+  "scripts": {
+    "test": "node run-tests.mjs"
+  },
   "devDependencies": {
+    "fengari": "^0.1.4",
     "luaparse": "^0.3.1"
   }
 }

--- a/tools/test/run-tests.mjs
+++ b/tools/test/run-tests.mjs
@@ -1,0 +1,97 @@
+// run-tests.mjs - offline logic tests for FS25_SoilFertilizer.
+//
+// For each tools/test/lua/*_test.lua, builds a single Lua program of:
+//   prelude.lua  +  the src modules it declares  +  the test file  +  T.summary()
+// runs it in a fresh fengari (Lua) state, captures stdout, and parses the
+// ##TEST_PASS / ##TEST_FAIL / ##TEST_SUMMARY markers the framework emits.
+//
+// A test declares which real src files to load with a header line:
+//   --!load: src/config/Constants.lua, src/SoilFertilitySystem.lua
+//
+// Usage:  node run-tests.mjs
+// Exit:   0 = all assertions passed, 1 = any failure or Lua load error.
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import fengari from "fengari";
+import { REPO_ROOT, rel, c } from "./lib.mjs";
+
+const { lua, lauxlib, lualib, to_luastring } = fengari;
+const LUA_DIR = fileURLToPath(new URL("./lua", import.meta.url));
+const prelude = readFileSync(join(LUA_DIR, "prelude.lua"), "utf8");
+
+function parseDeps(src) {
+  const m = src.match(/--!load:\s*(.+)/);
+  if (!m) return [];
+  return m[1].split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+// Run one Lua program string, return { rc, out } with stdout captured.
+function runLua(program) {
+  let out = "";
+  const orig = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (s) => { out += s; return true; };
+  let rc, errMsg = "";
+  try {
+    const L = lauxlib.luaL_newstate();
+    lualib.luaL_openlibs(L);
+    rc = lauxlib.luaL_dostring(L, to_luastring(program));
+    if (rc !== lua.LUA_OK) {
+      errMsg = lua.lua_tojsstring(L, -1);
+    }
+  } finally {
+    process.stdout.write = orig;
+  }
+  return { rc, out, errMsg };
+}
+
+const testFiles = readdirSync(LUA_DIR).filter((f) => f.endsWith("_test.lua")).sort();
+if (testFiles.length === 0) {
+  console.log(c.yellow("No *_test.lua files found in tools/test/lua/."));
+  process.exit(0);
+}
+
+let totalPass = 0, totalFail = 0, hadError = false;
+
+for (const tf of testFiles) {
+  const testPath = join(LUA_DIR, tf);
+  const testSrc = readFileSync(testPath, "utf8");
+  const deps = parseDeps(testSrc);
+
+  const parts = [prelude];
+  for (const d of deps) {
+    try {
+      parts.push(`-- <<< ${d} >>>\n` + readFileSync(join(REPO_ROOT, d), "utf8"));
+    } catch {
+      console.log(c.red(`✗ ${tf}: cannot read declared dependency '${d}'`));
+      hadError = true;
+    }
+  }
+  parts.push(`-- <<< test: ${tf} >>>\n` + testSrc);
+  parts.push("\nT.summary()\n");
+
+  const { rc, out, errMsg } = runLua(parts.join("\n"));
+
+  if (rc !== 0) {
+    hadError = true;
+    console.log(c.red(`✗ ${c.bold(tf)} - Lua error while loading/running:`));
+    console.log(`  ${c.red(errMsg || "(no message)")}`);
+    continue;
+  }
+
+  const passes = [...out.matchAll(/^##TEST_PASS (.+)$/gm)].map((m) => m[1]);
+  const fails = [...out.matchAll(/^##TEST_FAIL (.+)$/gm)].map((m) => m[1]);
+  totalPass += passes.length;
+  totalFail += fails.length;
+
+  const status = fails.length === 0 ? c.green("✓") : c.red("✗");
+  console.log(`${status} ${c.bold(tf)} ${c.dim(`(${passes.length} passed, ${fails.length} failed)`)}`);
+  for (const f of fails) console.log(`    ${c.red("FAIL")} ${f}`);
+}
+
+console.log(
+  "\n" +
+    (totalFail === 0 && !hadError ? c.green("PASS") : c.red("FAIL")) +
+    ` - ${totalPass} assertion${totalPass === 1 ? "" : "s"} passed, ${totalFail} failed across ${testFiles.length} file${testFiles.length === 1 ? "" : "s"}.`
+);
+process.exit(totalFail === 0 && !hadError ? 0 : 1);


### PR DESCRIPTION
## RSF-F223 — payroll dates, farm ownership and the loan bill read

Owner repair for the monthly-salary system plus the pure read the **C3 / RSF-F130 emergency loan** consumes. One item, homed in WorkerCosts; the loan remains usable without this companion.

### Repairs
- **Calendar:** `checkMonthEnd` now fires on native `currentDayInPeriod == daysPerPeriod`, keyed by the `year*PERIODS_IN_YEAR + period - 1` ordinal. The old `currentDay >= currentPeriod*28` never reached the last day of a non-28-day month (a 3-day month issued no bill). Fires once per period; a new year's same period issues again.
- **Per-farm attribution (F225):** accrual is nested `monthlyCosts[farmId][workerKey]`. A worker shared by two farms no longer pools into the first farm.
- **Frozen bills:** month end freezes one immutable bill with per-farm parts (exact base rows, priced final, `UNPAID/PAID/INDETERMINATE`). Pay/Decline bind to the exact bill id; Decline returns the unpaid base rows to accrual so the 20% late penalty never compounds into principal.
- **`addMoney` predicate:** a known non-wage `MoneyType` (e.g. `OTHER`) is forwarded through the captured chain instead of being swallowed by the missing-enum magnitude heuristic — so the loan's typed charges pass through. AI/WORKER_WAGES keep their real suppression.
- **Reader:** new `WorkerManager:getPayrollObligations(farmId, horizon)` — server-only, pure, returns a copied v1 snapshot of dated payroll cash bills (issued bills due now + next-payday unbilled work). Never mutates, issues, pays, flushes or migrates.
- **Persistence:** `workerMonthlySalary.xml` → schema 2 (nested accrual, frozen bills, issuance ordinal, `nextBillId`, legacy-unattributed rows). Schema 1 migrates on load — valid farms carried, missing/invalid targets retained as evidence, never defaulted.
- **MP→SP conversion:** native `g_farmManager.mergedFarms` remap applied once on load; parts keep identity and paid markers so a repeat map cannot double-pool.

### Verification
- Offline contract test bound to the **repaired** functions (the pre-repair defect witnesses were re-pointed to assert the fix, not loosened), plus lifecycle regressions for freeze/pay/decline and the reader: **178 assertions, 0 failures** (fengari; `npm test` in `tools/test`).
- Lua 5.1 syntax gate green (pre-commit).

### Still owed to the release lane (in-game observations, per the brief)
Native save/reload XML round-trip, actual MP→SP conversion, native `addMoney` exception behavior, and real two-farm/dedicated sessions. Contract tests do not prove these.
